### PR TITLE
Export a User configuration entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Media MPX for Drupal 8
+# Media mpx for Drupal 8
 
 [![CircleCI](https://circleci.com/gh/Lullabot/media_mpx.svg?style=svg)](https://circleci.com/gh/Lullabot/media_mpx) [![Maintainability](https://api.codeclimate.com/v1/badges/69160a3010c6788be915/maintainability)](https://codeclimate.com/github/Lullabot/media_mpx/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/69160a3010c6788be915/test_coverage)](https://codeclimate.com/github/Lullabot/media_mpx/test_coverage)
 
-This module integrates [MPX for PHP](https://github.com/Lullabot/mpx-php) with
+This module integrates [mpx for PHP](https://github.com/Lullabot/mpx-php) with
 Drupal 8's Media API.
 
 ## Requirements
@@ -10,3 +10,10 @@ Drupal 8's Media API.
 * Composer to fetch the various libraries this module is built on.
 * Drupal 8.5+
 * PHP 7.0+
+
+## About the mpx name
+
+mpx is not an acronym, and is used by thePlatform with capitals in all-caps
+sentences. This makes for some odd displays in Drupal, that generally expect
+title case or sentence case. When referring to mpx within the user interface
+and in strings, use lower case such as 'the mpx User entity'.

--- a/config/schema/media_mpx_user.schema.yml
+++ b/config/schema/media_mpx_user.schema.yml
@@ -1,0 +1,12 @@
+media_mpx.media_mpx_user.*:
+  type: config_entity
+  label: 'MPX User config'
+  mapping:
+    id:
+      type: string
+      label: 'ID'
+    username:
+      type: string
+      label: 'Username'
+    uuid:
+      type: string

--- a/media_mpx.links.action.yml
+++ b/media_mpx.links.action.yml
@@ -1,6 +1,6 @@
 entity.media_mpx_user.add_form:
   route_name: entity.media_mpx_user.add_form
-  title: 'Add MPX User'
+  title: 'Add mpx User'
   appears_on:
     - entity.media_mpx_user.collection
 

--- a/media_mpx.links.action.yml
+++ b/media_mpx.links.action.yml
@@ -1,0 +1,6 @@
+entity.media_mpx_user.add_form:
+  route_name: entity.media_mpx_user.add_form
+  title: 'Add MPX User'
+  appears_on:
+    - entity.media_mpx_user.collection
+

--- a/media_mpx.links.action.yml
+++ b/media_mpx.links.action.yml
@@ -3,4 +3,3 @@ entity.media_mpx_user.add_form:
   title: 'Add mpx User'
   appears_on:
     - entity.media_mpx_user.collection
-

--- a/media_mpx.links.menu.yml
+++ b/media_mpx.links.menu.yml
@@ -5,4 +5,3 @@ entity.media_mpx_user.collection:
   description: 'Manage mpx user accounts.'
   parent: system.admin_config_media
   weight: 99
-

--- a/media_mpx.links.menu.yml
+++ b/media_mpx.links.menu.yml
@@ -1,8 +1,8 @@
 # MPX User menu items definition
 entity.media_mpx_user.collection:
-  title: 'MPX User'
+  title: 'mpx Users'
   route_name: entity.media_mpx_user.collection
-  description: 'List MPX User (bundles)'
-  parent: system.admin_structure
+  description: 'Manage mpx user accounts.'
+  parent: system.admin_config_media
   weight: 99
 

--- a/media_mpx.links.menu.yml
+++ b/media_mpx.links.menu.yml
@@ -1,0 +1,8 @@
+# MPX User menu items definition
+entity.media_mpx_user.collection:
+  title: 'MPX User'
+  route_name: entity.media_mpx_user.collection
+  description: 'List MPX User (bundles)'
+  parent: system.admin_structure
+  weight: 99
+

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -1,0 +1,4 @@
+services:
+  media_mpx.authenticated_client:
+    class: \Lullabot\Mpx\AuthenticatedClient
+    factory: media_mpx.authenticated_client_factory

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -5,11 +5,11 @@ namespace Drupal\media_mpx\Entity;
 use Drupal\Core\Config\Entity\ConfigEntityBase;
 
 /**
- * Defines the MPX User entity.
+ * Defines the mpx User entity.
  *
  * @ConfigEntityType(
  *   id = "media_mpx_user",
- *   label = @Translation("MPX User"),
+ *   label = @Translation("mpx User"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\media_mpx\UserListBuilder",
@@ -30,11 +30,11 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "canonical" = "/admin/structure/media_mpx_user/{media_mpx_user}",
- *     "add-form" = "/admin/structure/media_mpx_user/add",
- *     "edit-form" = "/admin/structure/media_mpx_user/{media_mpx_user}/edit",
- *     "delete-form" = "/admin/structure/media_mpx_user/{media_mpx_user}/delete",
- *     "collection" = "/admin/structure/media_mpx_user"
+ *     "canonical" = "/admin/config/media/media_mpx_user/{media_mpx_user}",
+ *     "add-form" = "/admin/config/media/media_mpx_user/add",
+ *     "edit-form" = "/admin/config/media/media_mpx_user/{media_mpx_user}/edit",
+ *     "delete-form" = "/admin/config/media/media_mpx_user/{media_mpx_user}/delete",
+ *     "collection" = "/admin/config/media/media_mpx_user"
  *   }
  * )
  */
@@ -48,14 +48,14 @@ class User extends ConfigEntityBase implements UserInterface {
   protected $id;
 
   /**
-   * The MPX User name.
+   * The mpx User name.
    *
    * @var string
    */
   protected $username;
 
   /**
-   * The MPX password.
+   * The mpx password.
    *
    * @var string
    */

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -61,4 +61,18 @@ class User extends ConfigEntityBase implements UserInterface {
    */
   protected $password;
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getUsername(): string {
+    return $this->username;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPassword(): string {
+    return $this->password;
+  }
+
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -29,6 +29,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label" = "username",
  *     "uuid" = "uuid"
  *   },
+ *   label_collection = @Translation("mpx Users"),
  *   links = {
  *     "canonical" = "/admin/config/media/media_mpx_user/{media_mpx_user}",
  *     "add-form" = "/admin/config/media/media_mpx_user/add",

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\media_mpx\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBase;
+
+/**
+ * Defines the MPX User entity.
+ *
+ * @ConfigEntityType(
+ *   id = "media_mpx_user",
+ *   label = @Translation("MPX User"),
+ *   handlers = {
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "list_builder" = "Drupal\media_mpx\UserListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\media_mpx\Form\UserForm",
+ *       "edit" = "Drupal\media_mpx\Form\UserForm",
+ *       "delete" = "Drupal\media_mpx\Form\UserDeleteForm"
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\media_mpx\UserHtmlRouteProvider",
+ *     },
+ *   },
+ *   config_prefix = "media_mpx_user",
+ *   admin_permission = "administer site configuration",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "username",
+ *     "uuid" = "uuid"
+ *   },
+ *   links = {
+ *     "canonical" = "/admin/structure/media_mpx_user/{media_mpx_user}",
+ *     "add-form" = "/admin/structure/media_mpx_user/add",
+ *     "edit-form" = "/admin/structure/media_mpx_user/{media_mpx_user}/edit",
+ *     "delete-form" = "/admin/structure/media_mpx_user/{media_mpx_user}/delete",
+ *     "collection" = "/admin/structure/media_mpx_user"
+ *   }
+ * )
+ */
+class User extends ConfigEntityBase implements UserInterface {
+
+  /**
+   * The machine name.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The MPX User name.
+   *
+   * @var string
+   */
+  protected $username;
+
+  /**
+   * The MPX password.
+   *
+   * @var string
+   */
+  protected $password;
+
+}

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -24,4 +24,5 @@ interface UserInterface extends ConfigEntityInterface {
    *   The mpx password.
    */
   public function getPassword(): string;
+
 }

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\media_mpx\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+/**
+ * Provides an interface for defining MPX User entities.
+ */
+interface UserInterface extends ConfigEntityInterface {
+
+  // Add get/set methods for your configuration properties here.
+}

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -5,9 +5,23 @@ namespace Drupal\media_mpx\Entity;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 
 /**
- * Provides an interface for defining MPX User entities.
+ * Provides an interface for defining mpx User entities.
  */
 interface UserInterface extends ConfigEntityInterface {
 
-  // Add get/set methods for your configuration properties here.
+  /**
+   * Return the mpx username.
+   *
+   * @return string
+   *   The mpx username.
+   */
+  public function getUsername(): string;
+
+  /**
+   * Return the mpx password.
+   *
+   * @return string
+   *   The mpx password.
+   */
+  public function getPassword(): string;
 }

--- a/src/Form/UserDeleteForm.php
+++ b/src/Form/UserDeleteForm.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 
 /**
- * Builds the form to delete MPX User entities.
+ * Builds the form to delete mpx User entities.
  */
 class UserDeleteForm extends EntityConfirmFormBase {
 

--- a/src/Form/UserDeleteForm.php
+++ b/src/Form/UserDeleteForm.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\media_mpx\Form;
+
+use Drupal\Core\Entity\EntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Builds the form to delete MPX User entities.
+ */
+class UserDeleteForm extends EntityConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete %name?', ['%name' => $this->entity->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.media_mpx_user.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->delete();
+
+    drupal_set_message(
+      $this->t('content @type: deleted @label.',
+        [
+          '@type' => $this->entity->bundle(),
+          '@label' => $this->entity->label(),
+        ]
+        )
+    );
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -21,7 +21,7 @@ class UserForm extends EntityForm {
     // @todo html5 placeholder
     $form['username'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('MPX user name'),
+      '#title' => $this->t('mpx user name'),
       '#maxlength' => 255,
       '#default_value' => $media_mpx_user->label(),
       '#description' => $this->t("The MPX user name."),
@@ -40,8 +40,8 @@ class UserForm extends EntityForm {
 
     $form['password'] = [
       '#type' => 'password',
-      '#title' => $this->t('MPX password'),
-      '#description' => $this->t('The MPX user password.'),
+      '#title' => $this->t('mpx password'),
+      '#description' => $this->t('The mpx user password.'),
     ];
 
     return $form;
@@ -56,13 +56,13 @@ class UserForm extends EntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label MPX User.', [
+        drupal_set_message($this->t('Created the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label MPX User.', [
+        drupal_set_message($this->t('Saved the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
     }

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\media_mpx\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class UserForm.
+ */
+class UserForm extends EntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $media_mpx_user = $this->entity;
+    // @todo Email validation.
+    // @todo html5 placeholder
+    $form['username'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('MPX user name'),
+      '#maxlength' => 255,
+      '#default_value' => $media_mpx_user->label(),
+      '#description' => $this->t("The MPX user name."),
+      '#required' => TRUE,
+    ];
+
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $media_mpx_user->id(),
+      '#machine_name' => [
+        'exists' => '\Drupal\media_mpx\Entity\User::load',
+        'source' => ['username'],
+      ],
+      '#disabled' => !$media_mpx_user->isNew(),
+    ];
+
+    $form['password'] = [
+      '#type' => 'password',
+      '#title' => $this->t('MPX password'),
+      '#description' => $this->t('The MPX user password.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $media_mpx_user = $this->entity;
+    $status = $media_mpx_user->save();
+
+    switch ($status) {
+      case SAVED_NEW:
+        drupal_set_message($this->t('Created the %label MPX User.', [
+          '%label' => $media_mpx_user->label(),
+        ]));
+        break;
+
+      default:
+        drupal_set_message($this->t('Saved the %label MPX User.', [
+          '%label' => $media_mpx_user->label(),
+        ]));
+    }
+    $form_state->setRedirectUrl($media_mpx_user->toUrl('collection'));
+  }
+
+}

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -56,13 +56,13 @@ class UserForm extends EntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        $this->messenger->addStatus($this->t('Created the %label mpx User.', [
+        $this->messenger()->addStatus($this->t('Created the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
         break;
 
       default:
-        $this->messenger->addStatus($this->t('Saved the %label mpx User.', [
+        $this->messenger()->addStatus($this->t('Saved the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
     }

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -56,13 +56,13 @@ class UserForm extends EntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label mpx User.', [
+        $this->messenger->addStatus($this->t('Created the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label mpx User.', [
+        $this->messenger->addStatus($this->t('Saved the %label mpx User.', [
           '%label' => $media_mpx_user->label(),
         ]));
     }

--- a/src/UserHtmlRouteProvider.php
+++ b/src/UserHtmlRouteProvider.php
@@ -4,7 +4,6 @@ namespace Drupal\media_mpx;
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
-use Symfony\Component\Routing\Route;
 
 /**
  * Provides routes for MPX User entities.
@@ -21,7 +20,6 @@ class UserHtmlRouteProvider extends AdminHtmlRouteProvider {
     $collection = parent::getRoutes($entity_type);
 
     // Provide your custom entity routes here.
-
     return $collection;
   }
 

--- a/src/UserHtmlRouteProvider.php
+++ b/src/UserHtmlRouteProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Provides routes for MPX User entities.
+ *
+ * @see Drupal\Core\Entity\Routing\AdminHtmlRouteProvider
+ * @see Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider
+ */
+class UserHtmlRouteProvider extends AdminHtmlRouteProvider {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRoutes(EntityTypeInterface $entity_type) {
+    $collection = parent::getRoutes($entity_type);
+
+    // Provide your custom entity routes here.
+
+    return $collection;
+  }
+
+}

--- a/src/UserListBuilder.php
+++ b/src/UserListBuilder.php
@@ -14,7 +14,7 @@ class UserListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader() {
-    $header['label'] = $this->t('MPX User');
+    $header['label'] = $this->t('mpx User');
     $header['id'] = $this->t('Machine name');
     return $header + parent::buildHeader();
   }

--- a/src/UserListBuilder.php
+++ b/src/UserListBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Provides a listing of MPX User entities.
+ */
+class UserListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('MPX User');
+    $header['id'] = $this->t('Machine name');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['label'] = $entity->label();
+    $row['id'] = $entity->id();
+    // You probably want a few more properties here...
+    return $row + parent::buildRow($entity);
+  }
+
+}


### PR DESCRIPTION
Since a site may have multiple mpx users, each associated with one or more mpx accounts, it makes sense to have "user" as it's own configuration object. Also, it means "accounts" can be totally exported with CMI, without worrying about accidentally exporting an mpx password to git.

For this PR, I've placed the menu item right under `Media`. However, once we add a second configuration entity, I will move it all into a config page for all mpx settings.

<img width="616" alt="configuration drush site-install 2018-04-04 13-35-01" src="https://user-images.githubusercontent.com/255023/38324003-fbc199c0-380c-11e8-8d87-daac9dde42f5.png">

<img width="710" alt="user example com drush site-install 2018-04-04 13-34-19" src="https://user-images.githubusercontent.com/255023/38323974-e665671e-380c-11e8-99c2-30e7b0ef42b2.png">
