### PR TITLE
Add service definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "license": "GPL-2.0+",
   "homepage": "https://www.drupal.org/project/media_mpx",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "support": {
     "issues": "https://www.drupal.org/project/issues/media_mpx",
     "source": "http://cgit.drupalcode.org/media_mpx"
@@ -18,13 +19,13 @@
     "symfony/property-info": "^3.4"
   },
   "require-dev": {
-    "cweagans/composer-patches": "dev-master",
+    "cweagans/composer-patches": "^1.6",
     "behat/mink-selenium2-driver": "1.3.x-dev",
     "behat/mink-extension": "v2.2",
     "drupal/coder": "^8.2",
     "drupal/drupal-extension": "master-dev",
-    "bex/behat-screenshot": "dev-master",
-    "phpmd/phpmd": "dev-master",
-    "phpmetrics/phpmetrics": "dev-master"
+    "bex/behat-screenshot": "^1.2",
+    "phpmd/phpmd": "^2.6",
+    "phpmetrics/phpmetrics": "^2.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
     "source": "http://cgit.drupalcode.org/media_mpx"
   },
   "require": {
+    "symfony/cache": "^3.4",
+    "highwire/drupal-psr-16": "^1.0",
     "lullabot/mpx-php": "dev-master",
+    "lullabot/drupal-symfony-lock": "dev-master",
     "symfony/property-info": "^3.4"
   },
   "require-dev": {

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -1,4 +1,48 @@
 services:
-  media_mpx.authenticated_client:
-    class: \Lullabot\Mpx\AuthenticatedClient
-    factory: media_mpx.authenticated_client_factory
+  # This is the service used to make authenticated requests to mpx.
+  media_mpx.authenticated_client_factory:
+    class: Drupal\media_mpx\AuthenticatedClientFactory
+    arguments: ['@media_mpx.client', '@media_mpx.user_session_factory']
+
+  media_mpx.data_object_factory:
+    class: Drupal\media_mpx\DataObjectFactory
+    arguments: ['@media_mpx.data_service_manager', '@media_mpx.authenticated_client_factory']
+
+  media_mpx.data_service_manager:
+    class: Lullabot\Mpx\DataService\DataServiceManager
+    public: false
+    factory: ['Lullabot\Mpx\DataService\DataServiceManager', basicDiscovery]
+
+  media_mpx.user_session_factory:
+    class: Drupal\media_mpx\UserSessionFactory
+    arguments: ['@media_mpx.client', '@media_mpx.session_lock', '@media_mpx.token_cache_pool']
+
+  # This service is a generic client handling both authenticated and anonymous
+  # requests. Most code will want to use media_mpx.authenticated_client_factory
+  # instead.
+  media_mpx.client:
+    class: Lullabot\Mpx\Client
+    arguments: ['@http_client']
+
+  # These services are "internal" and generally not needed by custom code.
+  media_mpx.session_lock:
+    class: Lullabot\DrupalSymfonyLock\DrupalStore
+    public: false
+    arguments: ['@lock']
+
+  # The mpx-php library implements PSR-6, but there is only a PSR-16 cache
+  # adapter for Drupal. We use Symfony to bridge PSR-16 to PSR-6.
+  media_mpx.simple_cache_backend:
+    class: HighWire\DrupalPSR16\Cache
+    public: false
+    arguments: ['@cache.default']
+
+  media_mpx.token_cache_pool_adapter:
+    class: Symfony\Component\Cache\Adapter\SimpleCacheAdapter
+    public: false
+    arguments: ['@media_mpx.simple_cache_backend', 'media_mpx_token']
+
+  media_mpx.token_cache_pool:
+    class: Lullabot\Mpx\TokenCachePool
+    public: false
+    arguments: ['@media_mpx.token_cache_pool_adapter']

--- a/src/AuthenticatedClientFactory.php
+++ b/src/AuthenticatedClientFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\media_mpx\Entity\UserInterface;
+use Lullabot\Mpx\AuthenticatedClient;
+use Lullabot\Mpx\Client;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+
+/**
+ * Factory to create Authenticated mpx Clients.
+ */
+class AuthenticatedClientFactory {
+
+  /**
+   * The underlying client for all mpx requests.
+   *
+   * @var \Lullabot\Mpx\Client
+   */
+  private $client;
+
+  /**
+   * The factory used to create user sessions.
+   *
+   * @var \Drupal\media_mpx\UserSessionFactory
+   */
+  private $userSessionFactory;
+
+  /**
+   * Construct a new AuthenticatedClientFactory.
+   *
+   * @param \Lullabot\Mpx\Client $client
+   *   The underlying client for all mpx requests.
+   * @param \Drupal\media_mpx\UserSessionFactory $userSessionFactory
+   *   The factory used to create user sessions.
+   */
+  public function __construct(Client $client, UserSessionFactory $userSessionFactory) {
+    $this->client = $client;
+    $this->userSessionFactory = $userSessionFactory;
+  }
+
+  /**
+   * Create a new Authenticated Client from an existing user session.
+   *
+   * @param \Lullabot\Mpx\Service\IdentityManagement\UserSession $session
+   *   The user session to create the client for.
+   *
+   * @return \Lullabot\Mpx\AuthenticatedClient
+   *   A new authenticated client.
+   */
+  public function fromSession(UserSession $session): AuthenticatedClient {
+    return new AuthenticatedClient($this->client, $session);
+  }
+
+  /**
+   * Create a session for a user and return an authenticated client.
+   *
+   * @param \Drupal\media_mpx\Entity\UserInterface $user
+   *   The user to create the session for.
+   *
+   * @return \Lullabot\Mpx\AuthenticatedClient
+   *   A new authenticated client.
+   */
+  public function fromUser(UserInterface $user): AuthenticatedClient {
+    $session = $this->userSessionFactory->fromUser($user);
+    return $this->fromSession($session);
+  }
+
+}

--- a/src/DataObjectFactory.php
+++ b/src/DataObjectFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Lullabot\Mpx\DataService\DataObjectFactory as MpxDataObjectFactory;
+use Drupal\media_mpx\Entity\User;
+use Lullabot\Mpx\DataService\DataServiceManager;
+
+/**
+ * Factory used to load Data Objects from mpx.
+ */
+class DataObjectFactory {
+
+  /**
+   * The manager used to discover what mpx objects are available.
+   *
+   * @var \Lullabot\Mpx\DataService\DataServiceManager
+   */
+  private $manager;
+
+  /**
+   * A factory used to generate new authenticated clients.
+   *
+   * @var \Drupal\media_mpx\AuthenticatedClientFactory
+   */
+  private $authenticatedClientFactory;
+
+  /**
+   * Construct a new DataObjectFactory.
+   *
+   * @param \Lullabot\Mpx\DataService\DataServiceManager $manager
+   *   The manager used to discover what mpx objects are available.
+   * @param \Drupal\media_mpx\AuthenticatedClientFactory $authenticatedClientFactory
+   *   A factory used to generate new authenticated clients.
+   */
+  public function __construct(DataServiceManager $manager, AuthenticatedClientFactory $authenticatedClientFactory) {
+    $this->manager = $manager;
+    $this->authenticatedClientFactory = $authenticatedClientFactory;
+  }
+
+  /**
+   * Create a new \Lullabot\Mpx\DataService\DataObjectFactory for an mpx object.
+   *
+   * @param \Drupal\media_mpx\Entity\User $user
+   *   The user to authenticate the connection with.
+   * @param string $serviceName
+   *   The mpx service name, such as 'Media Data Service'.
+   * @param string $objectType
+   *   The object type to load, such as 'Media'.
+   * @param string $schema
+   *   The schema version to use, such as '1.10'.
+   *
+   * @return \Lullabot\Mpx\DataService\DataObjectFactory
+   *   A factory to load and query objects with.
+   */
+  public function forObjectType(User $user, string $serviceName, string $objectType, string $schema): MpxDataObjectFactory {
+    $service = $this->manager->getDataService($serviceName, $objectType, $schema);
+    $client = $this->authenticatedClientFactory->fromUser($user);
+    return new MpxDataObjectFactory($service, $client);
+  }
+
+}

--- a/src/UserSessionFactory.php
+++ b/src/UserSessionFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\TokenCachePool;
+use Symfony\Component\Lock\StoreInterface;
+use Lullabot\Mpx\Client;
+use Drupal\media_mpx\Entity\UserInterface;
+use Lullabot\Mpx\Service\IdentityManagement\User;
+
+/**
+ * Factory used to create mpx user sessions.
+ */
+class UserSessionFactory {
+
+  /**
+   * The underlying mpx API client.
+   *
+   * @var \Lullabot\Mpx\Client
+   */
+  private $client;
+
+  /**
+   * The lock store used to prevent sign-in stampedes.
+   *
+   * @var \Symfony\Component\Lock\StoreInterface
+   */
+  private $store;
+
+  /**
+   * The cache of authentication tokens.
+   *
+   * @var \Lullabot\Mpx\TokenCachePool
+   */
+  private $tokenCachePool;
+
+  /**
+   * Construct a new UserSessionFactory.
+   *
+   * @param \Lullabot\Mpx\Client $client
+   *   The underlying mpx API client.
+   * @param \Symfony\Component\Lock\StoreInterface $store
+   *   The lock store used to prevent sign-in stampedes.
+   * @param \Lullabot\Mpx\TokenCachePool $tokenCachePool
+   *   The cache of authentication tokens.
+   */
+  public function __construct(Client $client, StoreInterface $store, TokenCachePool $tokenCachePool) {
+    $this->client = $client;
+    $this->store = $store;
+    $this->tokenCachePool = $tokenCachePool;
+  }
+
+  /**
+   * Create a session for a user.
+   *
+   * @param \Drupal\media_mpx\Entity\UserInterface $user
+   *   The user to create the session for.
+   *
+   * @return \Lullabot\Mpx\Service\IdentityManagement\UserSession
+   *   The new user session.
+   */
+  public function fromUser(UserInterface $user): UserSession {
+    $mpx_user = new User($user->getUsername(), $user->getPassword());
+    return new UserSession($mpx_user, $this->client, $this->store, $this->tokenCachePool);
+  }
+
+}


### PR DESCRIPTION
Depends on #3 .

This PR adds service definitions and factory classes to simplify working with the mpx API. For example, lets say a developer wants to load all mpx accounts:

```php
<?php

/** @var \Drupal\media_mpx\DataObjectFactory $factory */
$factory = \Drupal::service('media_mpx.data_object_factory');
// $user is a User configuration entity.
$dof = $factory->forMpxObject($user, 'Access Data Service', 'Account', '1.0');

// This selects all accounts with no filters, we need to make the parameter optional in `select()`.
$fields = new \Lullabot\Mpx\DataService\ByFields();
$accounts = $dof->select($fields);
foreach ($accounts as $account) {
  // Access account properties like $account->getId(), $account->getTitle()...
}
```