### PR TITLE
WIP: Support saving the complete media object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "symfony/property-info": "^3.4"
   },
   "require-dev": {
-    "cweagans/composer-patches": "dev-master",
+    "cweagans/composer-patches": "^1.6.4",
     "behat/mink-selenium2-driver": "1.3.x-dev",
     "behat/mink-extension": "v2.2",
     "drupal/coder": "^8.2",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "source": "http://cgit.drupalcode.org/media_mpx"
   },
   "require": {
+    "drupal/entity_keyvalue": "^1.0",
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
     "lullabot/mpx-php": "dev-master",

--- a/config/schema/media_mpx.schema.yml
+++ b/config/schema/media_mpx.schema.yml
@@ -10,6 +10,12 @@ media_mpx.media_mpx_account.*:
       label: Label
     uuid:
       type: string
+    user:
+      label: The user configuration entity associated with this account
+      type: string
+    account:
+      label: The URI of the account
+      type: uri
 
 media_mpx.media_mpx_user.*:
   type: config_entity

--- a/config/schema/media_mpx.schema.yml
+++ b/config/schema/media_mpx.schema.yml
@@ -21,5 +21,8 @@ media_mpx.media_mpx_user.*:
     username:
       type: string
       label: 'Username'
+    password:
+      type: string
+      label: 'Password'
     uuid:
       type: string

--- a/media_mpx.info.yml
+++ b/media_mpx.info.yml
@@ -6,4 +6,5 @@ core: 8.x
 package: 'Media'
 dependencies:
   - drupal:media (>=8.5.0)
+  - entity_keyvalue:entity_keyvalue
 configure: entity.media_mpx_account.collection

--- a/media_mpx.module
+++ b/media_mpx.module
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\media\MediaInterface;
+use Drupal\media_mpx\Exception\SourceObjectNotFoundException;
 
 /**
  * Implements hook_help().
@@ -25,4 +27,22 @@ function media_mpx_help($route_name, RouteMatchInterface $route_match) {
   }
 
   return NULL;
+}
+
+/**
+ * Implements hook_entity_keyvalue_info().
+ */
+function media_mpx_entity_keyvalue_info() {
+  return [
+    'media' => [
+      'keys' => [
+        'source_object' => [
+          'default_value' => function (MediaInterface $media) {
+            throw new SourceObjectNotFoundException();
+          },
+          'type' => 'object',
+        ],
+      ],
+    ],
+  ];
 }

--- a/src/DataObjectFactory.php
+++ b/src/DataObjectFactory.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\media_mpx;
 
+use Drupal\media_mpx\Entity\UserInterface;
 use Lullabot\Mpx\DataService\DataObjectFactory as MpxDataObjectFactory;
-use Drupal\media_mpx\Entity\User;
 use Lullabot\Mpx\DataService\DataServiceManager;
 
 /**
@@ -41,7 +41,7 @@ class DataObjectFactory {
   /**
    * Create a new \Lullabot\Mpx\DataService\DataObjectFactory for an mpx object.
    *
-   * @param \Drupal\media_mpx\Entity\User $user
+   * @param \Drupal\media_mpx\Entity\UserInterface $user
    *   The user to authenticate the connection with.
    * @param string $serviceName
    *   The mpx service name, such as 'Media Data Service'.
@@ -53,7 +53,7 @@ class DataObjectFactory {
    * @return \Lullabot\Mpx\DataService\DataObjectFactory
    *   A factory to load and query objects with.
    */
-  public function forObjectType(User $user, string $serviceName, string $objectType, string $schema): MpxDataObjectFactory {
+  public function forObjectType(UserInterface $user, string $serviceName, string $objectType, string $schema): MpxDataObjectFactory {
     $service = $this->manager->getDataService($serviceName, $objectType, $schema);
     $client = $this->authenticatedClientFactory->fromUser($user);
     return new MpxDataObjectFactory($service, $client);

--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -58,4 +58,18 @@ class Account extends ConfigEntityBase implements AccountInterface {
    */
   protected $status;
 
+  /**
+   * The entity id of the User configuration entity.
+   *
+   * @var string
+   */
+  protected $user;
+
+  /**
+   * The URI of the account.
+   *
+   * @var mixed
+   */
+  protected $account;
+
 }

--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -72,4 +72,16 @@ class Account extends ConfigEntityBase implements AccountInterface {
    */
   protected $account;
 
+  /**
+   * Get the User configuration entity associated with this account.
+   *
+   * @return \Drupal\media_mpx\Entity\UserInterface
+   *   The User configuration entity.
+   */
+  public function getUserEntity(): UserInterface {
+    /** @var \Drupal\media_mpx\Entity\UserInterface $user */
+    $user = $this->entityTypeManager()->getStorage('media_mpx_user')->load($this->user);
+    return $user;
+  }
+
 }

--- a/src/Exception/SourceObjectNotFoundException.php
+++ b/src/Exception/SourceObjectNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\media_mpx\Exception;
+
+/**
+ * Exception thrown when a source object in the key-value store is not found.
+ */
+class SourceObjectNotFoundException extends \RuntimeException {
+
+}

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -4,6 +4,7 @@ namespace Drupal\media_mpx\Form;
 
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Mpx Account form.
@@ -35,6 +36,26 @@ class AccountForm extends EntityForm {
         'exists' => '\Drupal\media_mpx\Entity\MpxAccount::load',
       ],
       '#disabled' => !$this->entity->isNew(),
+    ];
+
+    $users = array_map(function ($entity) {
+      /** @var \Drupal\media_mpx\Entity\UserInterface $entity */
+      return $entity->label();
+    }, $this->entityTypeManager->getStorage('media_mpx_user')->loadMultiple());
+
+    if (empty($users)) {
+      $url = Url::fromRoute('entity.media_mpx_user.add_form')->toString() . '?destination=' . \Drupal::service('path.current')->getPath();
+      $this->messenger()->addError($this->t('<a href="@add-user">Create at least one mpx user</a> before creating accounts.', [
+        '@add-user' => $url,
+      ]));
+      return [];
+    }
+
+    $form['user'] = [
+      '#type' => 'select',
+      '#title' => $this->t('mpx user'),
+      '#description' => $this->t('Select an mpx user to see what accounts are available.'),
+      '#options' => $users,
     ];
 
     $form['status'] = [

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -62,7 +62,7 @@ class AccountForm extends EntityForm {
 
     $form = $this->idLabelForm($form);
 
-    $users = $this->loadMpxUsers();
+    $users = $this->loadMpxUsers($form_state);
     if (empty($users)) {
       $url = Url::fromRoute('entity.media_mpx_user.add_form')->toString() . '?destination=' . \Drupal::service('path.current')->getPath();
       $this->messenger()->addError($this->t('<a href="@add-user">Create at least one mpx user</a> before creating accounts.', [
@@ -173,12 +173,6 @@ class AccountForm extends EntityForm {
       ],
     ];
 
-    // Set the currently selected user on the initial load.
-    if (!$form_state->hasValue('user')) {
-      reset($users);
-      $form_state->setValue('user', key($users));
-    }
-
     $this->fetchAccounts($form, $form_state);
     return $form;
   }
@@ -216,14 +210,24 @@ class AccountForm extends EntityForm {
   /**
    * Return all configured mpx user names, keyed by their config entity ID.
    *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
    * @return array
    *   An array of user names, keyed by the config entity ID.
    */
-  private function loadMpxUsers(): array {
+  private function loadMpxUsers(FormStateInterface $form_state): array {
     $users = array_map(function ($entity) {
       /** @var \Drupal\media_mpx\Entity\UserInterface $entity */
       return $entity->label();
     }, $this->entityTypeManager->getStorage('media_mpx_user')->loadMultiple());
+
+    // Set the currently selected user on the initial load.
+    if (!$form_state->hasValue('user')) {
+      reset($users);
+      $form_state->setValue('user', key($users));
+    }
+
     return $users;
   }
 

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -38,6 +38,7 @@ class AccountForm extends EntityForm {
       '#disabled' => !$this->entity->isNew(),
     ];
 
+    /** @var \Drupal\media_mpx\Entity\UserInterface[] $users */
     $users = array_map(function ($entity) {
       /** @var \Drupal\media_mpx\Entity\UserInterface $entity */
       return $entity->label();
@@ -56,7 +57,24 @@ class AccountForm extends EntityForm {
       '#title' => $this->t('mpx user'),
       '#description' => $this->t('Select an mpx user to see what accounts are available.'),
       '#options' => $users,
+      '#ajax' => [
+        'callback' => [$this, 'fetchAccounts'],
+        'event' => 'change',
+        'wrapper' => 'media-mpx-accounts',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => $this->t('Fetching mpx accounts…'),
+        ],
+      ],
     ];
+    $form_state->setValue('user', reset(array_keys($users)));
+
+//    $form['accounts_wrapper'] = [
+//      '#prefix' => '<div id="media-mpx-accounts">',
+//      '#suffix' => '</div>',
+//    ];
+
+    $form['account'] = $this->fetchAccounts($form, $form_state);
 
     $form['status'] = [
       '#type' => 'checkbox',
@@ -65,6 +83,33 @@ class AccountForm extends EntityForm {
     ];
 
     return $form;
+  }
+
+  public function fetchAccounts(array &$form, FormStateInterface $form_state) : array {
+    $user_entity_id = $form_state->getValue('user');
+    $user = $this->entityTypeManager->getStorage('media_mpx_user')->load($user_entity_id);
+
+    list($account, $accounts) = $this->ignoreThisForNow($user);
+
+    $options = [];
+    foreach ($accounts as $account) {
+      $options[(string) $account->getId()] = $this->t('@title (@id)', [
+        '@title' => $account->getTitle(),
+        '@id' => end(explode('/', $account->getId()->getPath())),
+      ]);
+    }
+    return [
+      'accounts_wrapper' => [
+        '#prefix' => '<div id="media-mpx-accounts">',
+        'accounts' => [
+          // If I change this to 'select' everything works.
+          '#type' => 'radios',
+          '#title' => $this->t('mpx account'),
+          '#options' => $options,
+        ],
+        '#suffix' => '</div>',
+      ],
+    ];
   }
 
   /**
@@ -79,6 +124,33 @@ class AccountForm extends EntityForm {
     $this->messenger()->addStatus($message);
     $form_state->setRedirectUrl($this->entity->toUrl('collection'));
     return $result;
+  }
+
+  /**
+   * @param $user
+   *
+   * @return array
+   */
+  private function ignoreThisForNow($user): array {
+    $manager = \Lullabot\Mpx\DataService\DataServiceManager::basicDiscovery();
+    $client = new \Lullabot\Mpx\Client(\Drupal::httpClient());
+    $store = new \Lullabot\DrupalSymfonyLock\DrupalStore(\Drupal::lock());
+    $p = new \HighWire\DrupalPSR16\Cache(\Drupal::cache('default'));
+    $p = new \Symfony\Component\Cache\Adapter\SimpleCacheAdapter($p);
+    $tokenCachePool = new \Lullabot\Mpx\TokenCachePool($p);
+    $mpx_user = new \Lullabot\Mpx\Service\IdentityManagement\User($user->getUsername(), $user->getPassword());
+    $session = new \Lullabot\Mpx\Service\IdentityManagement\UserSession($mpx_user, $client, $store, $tokenCachePool);
+    $client = new \Lullabot\Mpx\AuthenticatedClient($client, $session);
+    $data_service = $manager->getDataService('Access Data Service', 'Account', '1.0');
+    $dof = new \Lullabot\Mpx\DataService\DataObjectFactory($data_service, $client);
+
+    $fields = new \Lullabot\Mpx\DataService\ByFields();
+
+    $account = new \Lullabot\Mpx\DataService\Access\Account();
+    $account->setId($session->acquireToken()->getUserId());
+    /** @var \Lullabot\Mpx\DataService\Access\Account $account */
+    $accounts = $dof->select($fields, $account);
+    return [$account, $accounts];
   }
 
 }

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -11,7 +11,7 @@ use Lullabot\Mpx\DataService\ByFields;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Mpx Account form.
+ * The mpx Account form.
  *
  * @property \Drupal\media_mpx\AccountInterface $entity
  */
@@ -58,33 +58,11 @@ class AccountForm extends EntityForm {
    * {@inheritdoc}
    */
   public function form(array $form, FormStateInterface $form_state) {
-
     $form = parent::form($form, $form_state);
 
-    $form['label'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Label'),
-      '#maxlength' => 255,
-      '#default_value' => $this->entity->label(),
-      '#description' => $this->t('Label for the mpx account.'),
-      '#required' => TRUE,
-    ];
+    $form = $this->idLabelForm($form);
 
-    $form['id'] = [
-      '#type' => 'machine_name',
-      '#default_value' => $this->entity->id(),
-      '#machine_name' => [
-        'exists' => '\Drupal\media_mpx\Entity\MpxAccount::load',
-      ],
-      '#disabled' => !$this->entity->isNew(),
-    ];
-
-    /** @var \Drupal\media_mpx\Entity\UserInterface[] $users */
-    $users = array_map(function ($entity) {
-      /** @var \Drupal\media_mpx\Entity\UserInterface $entity */
-      return $entity->label();
-    }, $this->entityTypeManager->getStorage('media_mpx_user')->loadMultiple());
-
+    $users = $this->loadMpxUsers();
     if (empty($users)) {
       $url = Url::fromRoute('entity.media_mpx_user.add_form')->toString() . '?destination=' . \Drupal::service('path.current')->getPath();
       $this->messenger()->addError($this->t('<a href="@add-user">Create at least one mpx user</a> before creating accounts.', [
@@ -93,37 +71,7 @@ class AccountForm extends EntityForm {
       return [];
     }
 
-    $form['user'] = [
-      '#type' => 'select',
-      '#title' => $this->t('mpx user'),
-      '#description' => $this->t('Select an mpx user to see what accounts are available.'),
-      '#options' => $users,
-      '#default_value' => $this->entity->get('user'),
-      '#ajax' => [
-        'callback' => [$this, 'fetchAccounts'],
-        'event' => 'change',
-        'wrapper' => 'media-mpx-accounts',
-        'progress' => [
-          'type' => 'throbber',
-          'message' => $this->t('Fetching mpx accounts…'),
-        ],
-      ],
-    ];
-
-    $form['accounts_container'] = [
-      '#type' => 'container',
-      '#attributes' => [
-        'id' => 'media-mpx-accounts',
-      ],
-    ];
-
-    // Set the currently selected user on the initial load.
-    if (!$form_state->hasValue('user')) {
-      reset($users);
-      $form_state->setValue('user', key($users));
-    }
-
-    $this->fetchAccounts($form, $form_state);
+    $form = $this->userAccountForm($form, $form_state, $users);
 
     $form['status'] = [
       '#type' => 'checkbox',
@@ -185,6 +133,98 @@ class AccountForm extends EntityForm {
     $this->messenger()->addStatus($message);
     $form_state->setRedirectUrl($this->entity->toUrl('collection'));
     return $result;
+  }
+
+  /**
+   * Return the mpx user and account selection form.
+   *
+   * @param array $form
+   *   The current form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array $users
+   *   An array of mpx User options.
+   *
+   * @return array
+   *   The complete form.
+   */
+  private function userAccountForm(array $form, FormStateInterface $form_state, array $users): array {
+    $form['user'] = [
+      '#type' => 'select',
+      '#title' => $this->t('mpx user'),
+      '#description' => $this->t('Select an mpx user to see what accounts are available.'),
+      '#options' => $users,
+      '#default_value' => $this->entity->get('user'),
+      '#ajax' => [
+        'callback' => [$this, 'fetchAccounts'],
+        'event' => 'change',
+        'wrapper' => 'media-mpx-accounts',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => $this->t('Fetching mpx accounts…'),
+        ],
+      ],
+    ];
+
+    $form['accounts_container'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'media-mpx-accounts',
+      ],
+    ];
+
+    // Set the currently selected user on the initial load.
+    if (!$form_state->hasValue('user')) {
+      reset($users);
+      $form_state->setValue('user', key($users));
+    }
+
+    $this->fetchAccounts($form, $form_state);
+    return $form;
+  }
+
+  /**
+   * Return the id and label fields.
+   *
+   * @param array $form
+   *   The current form.
+   *
+   * @return array
+   *   The complete form.
+   */
+  private function idLabelForm(array $form): array {
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#maxlength' => 255,
+      '#default_value' => $this->entity->label(),
+      '#description' => $this->t('Label for the mpx account.'),
+      '#required' => TRUE,
+    ];
+
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $this->entity->id(),
+      '#machine_name' => [
+        'exists' => '\Drupal\media_mpx\Entity\MpxAccount::load',
+      ],
+      '#disabled' => !$this->entity->isNew(),
+    ];
+    return $form;
+  }
+
+  /**
+   * Return all configured mpx user names, keyed by their config entity ID.
+   *
+   * @return array
+   *   An array of user names, keyed by the config entity ID.
+   */
+  private function loadMpxUsers(): array {
+    $users = array_map(function ($entity) {
+      /** @var \Drupal\media_mpx\Entity\UserInterface $entity */
+      return $entity->label();
+    }, $this->entityTypeManager->getStorage('media_mpx_user')->loadMultiple());
+    return $users;
   }
 
 }

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -164,6 +164,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
       $id = $media->get($this->configuration['source_field'])->getString();
       $mpx_media = $mediaFactory->load($id);
       $method = 'get' . ucfirst($attribute_name);
+      // @todo At the least this should be a static cache tied to $media.
       $value = $mpx_media->wait()->$method();
 
       // @todo Is this the best way to handle complex values like dates and

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Drupal\media_mpx\Plugin\media\Source;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldTypePluginManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaSourceBase;
+use Drupal\media\MediaSourceInterface;
+use Drupal\media_mpx\DataObjectFactory;
+use Drupal\media_mpx\Entity\Account;
+use Lullabot\Mpx\DataService\Media\Media as MpxMedia;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+/**
+ * Media source for mpx Media items.
+ *
+ * @see \Lullabot\Mpx\DataService\Media\Media
+ * @see https://docs.theplatform.com/help/media-media-object
+ *
+ * @MediaSource(
+ *   id = "media_mpx_media",
+ *   label = @Translation("mpx Media"),
+ *   description = @Translation("mpx media data, such as videos."),
+ *   allowed_field_types = {"string"},
+ *   default_thumbnail_filename = "video.png"
+ * )
+ */
+class Media extends MediaSourceBase implements MediaSourceInterface {
+  use MessengerTrait;
+
+  /**
+   * The service to load mpx data.
+   *
+   * @var \Drupal\media_mpx\DataObjectFactory
+   */
+  private $dataObjectFactory;
+
+  /**
+   * Media constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   Entity field manager service.
+   * @param \Drupal\Core\Field\FieldTypePluginManagerInterface $field_type_manager
+   *   The field type plugin manager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\media_mpx\DataObjectFactory $dataObjectFactory
+   *   The service to load mpx data.
+   */
+  public function __construct(array $configuration, string $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, FieldTypePluginManagerInterface $field_type_manager, ConfigFactoryInterface $config_factory, DataObjectFactory $dataObjectFactory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $entity_field_manager, $field_type_manager, $config_factory);
+    $this->dataObjectFactory = $dataObjectFactory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('plugin.manager.field.field_type'),
+      $container->get('config.factory'),
+      $container->get('media_mpx.data_object_factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return parent::defaultConfiguration() + [
+      'account' => NULL,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return parent::calculateDependencies() + [
+      'config' => [
+        'media_mpx.media_mpx_account.' . $this->getConfiguration()['account'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $accounts = $this->entityTypeManager->getStorage('media_mpx_account')->loadMultiple();
+
+    if (empty($accounts)) {
+      // @todo the #ajax callback isn't showing this, core bug?
+      $this->messenger()->addError($this->t('Create an account before configuring an mpx media type.'));
+      return $form;
+    }
+
+    $options = [];
+    foreach ($accounts as $account) {
+      $options[$account->id()] = $this->t('@title', [
+        '@title' => $account->label(),
+      ]);
+    }
+
+    $form['account'] = [
+      '#type' => 'select',
+      '#title' => $this->t('mpx account'),
+      '#description' => $this->t('Select the mpx account to associate with this media type.'),
+      '#default_value' => $this->getConfiguration()['account'],
+      '#options' => $options,
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadataAttributes() {
+    list($propertyInfo, $properties) = $this->extractMediaProperties();
+
+    $metadata = [];
+    foreach ($properties as $property) {
+      $metadata[$property] = $propertyInfo->getShortDescription(MpxMedia::class, $property);
+    }
+
+    return $metadata;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMetadata(MediaInterface $media, $attribute_name) {
+    $properties = $this->extractMediaProperties();
+
+    if (in_array($attribute_name, $properties)) {
+      $user = $this->getAccount()->getUserEntity();
+      $mediaFactory = $this->dataObjectFactory->forObjectType($user, 'Media Data Service', 'Media', '1.10');
+
+      $id = $media->get($this->configuration['source_field'])->getString();
+      $mpx_media = $mediaFactory->load($id);
+      $method = 'get' . ucfirst($attribute_name);
+      $value = $mpx_media->wait()->$method();
+
+      // @todo Is this the best way to handle complex values like dates and
+      // sub-objects?
+      if ($value instanceof \DateTime) {
+        $value = $value->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+      }
+
+      return $value;
+    }
+
+    return parent::getMetadata($media, $attribute_name);
+  }
+
+  /**
+   * Return the mpx account used for this media type.
+   *
+   * @return \Drupal\media_mpx\Entity\Account
+   *   The mpx account.
+   */
+  protected function getAccount(): Account {
+    $id = $this->getConfiguration()['account'];
+    /** @var \Drupal\media_mpx\Entity\Account $account */
+    $account = $this->entityTypeManager->getStorage('media_mpx_account')->load($id);
+    return $account;
+  }
+
+  /**
+   * Extract the properties available to set on a media entity.
+   *
+   * @return array
+   *   An array of property values and their descriptions.
+   */
+  private function extractMediaProperties(): array {
+    // @todo Cache this!
+    $phpDocExtractor = new PhpDocExtractor();
+    $reflectionExtractor = new ReflectionExtractor();
+
+    $listExtractors = [$reflectionExtractor];
+
+    $typeExtractors = [$phpDocExtractor, $reflectionExtractor];
+
+    $descriptionExtractors = [$phpDocExtractor];
+
+    $accessExtractors = [$reflectionExtractor];
+
+    $propertyInfo = new PropertyInfoExtractor(
+      $listExtractors,
+      $typeExtractors,
+      $descriptionExtractors,
+      $accessExtractors
+    );
+
+    // @todo This should probably be discovered and not hardcoded.
+    $class = MpxMedia::class;
+    return $propertyInfo->getProperties($class);
+  }
+
+}

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -155,7 +155,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
    * {@inheritdoc}
    */
   public function getMetadata(MediaInterface $media, $attribute_name) {
-    $properties = $this->extractMediaProperties();
+    list(, $properties) = $this->extractMediaProperties();
 
     if (in_array($attribute_name, $properties)) {
       $user = $this->getAccount()->getUserEntity();
@@ -219,7 +219,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
 
     // @todo This should probably be discovered and not hardcoded.
     $class = MpxMedia::class;
-    return $propertyInfo->getProperties($class);
+    return [$propertyInfo, $propertyInfo->getProperties($class)];
   }
 
 }


### PR DESCRIPTION
Fixes #7 and depends on #5 .

This PR uses the entity_keyvalue module to store the mpx Media object in the key / value store. See #7 for details of how we got here.