### PR TITLE
Custom field discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ sentences. This makes for some odd displays in Drupal, that generally expect
 title case or sentence case. When referring to mpx within the user interface
 and in strings, use lower case such as 'the mpx User entity'.
 
+## Custom field support
+
+Custom fields are defined in mpx and allow for additional data to be attached
+to media and other mpx objects. Custom fields are grouped by _namespaces_ and
+each object can have custom fields from any number of namespaces.
+
+Out of the box, custom fields will not be available on loaded mpx objects.
+If custom fields are used in mpx, but are not required in Drupal, then you
+can leave things as is and each set of custom fields will be represented by the
+`\Lullabot\Mpx\Normalizer\MissingCustomFieldsClass` class.
+
+To integrate custom fields:
+
+1. Follow the steps at https://github.com/Lullabot/mpx-php to generate the
+   initial custom fields classes. For example, if you wish to include the
+   classes in the `mysite_mpx` module, run:
+   `bin/console mpx:create-custom-field '\Drupal\mysite_mpx\Plugin\media_mpx\CustomField' 'Media Data Service' 'Media' '1.10'`
+1. Rename the classes to something that is reasonable for each set of data they
+   contain.
+1. Move the classes to `src/Plugin/media_mpx/CustomField` in your custom
+   module.
+1. Clear caches. When loading a Media item, your classes will be returned when
+   calling `getCustomFields($namespace)`, where `$namespace` is the mpx
+   namespace of your fields.
+
 ## Migrating from Media: thePlatform mpx
 
 Migrations should be run with Drush, using the

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "dev-discovery-interface",
+    "lullabot/mpx-php": "^0.1.1",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "^0.1.1",
+    "lullabot/mpx-php": "^0.2.0",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "^0.1.1",
+    "lullabot/mpx-php": "dev-discovery-interface",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4"
   },

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -11,7 +11,8 @@ services:
   media_mpx.data_service_manager:
     class: Lullabot\Mpx\DataService\DataServiceManager
     public: false
-    factory: ['Lullabot\Mpx\DataService\DataServiceManager', basicDiscovery]
+    factory: ['Lullabot\Mpx\DataService\DataServiceManager', 'basicDiscovery']
+    arguments: ['@media_mpx.custom_field_manager']
 
   media_mpx.user_session_factory:
     class: Drupal\media_mpx\UserSessionFactory
@@ -24,6 +25,15 @@ services:
   media_mpx.notification_listener:
     class: Drupal\media_mpx\NotificationListener
     arguments: ['@media_mpx.authenticated_client_factory', '@media_mpx.data_service_manager', '@state', '@logger.channel.media_mpx']
+
+  # Discovers custom field classes in all enabled modules
+  media_mpx.custom_field_discovery:
+    class: Drupal\media_mpx\CustomFieldDiscovery
+    arguments: ['@container.namespaces']
+
+  media_mpx.custom_field_manager:
+    class: Lullabot\Mpx\DataService\CustomFieldManager
+    arguments: ['@media_mpx.custom_field_discovery']
 
   # We need to define our own handler stack instance separate from Drupal
   # core's. Otherwise, when we add the mpx_errors handler, it gets applied to

--- a/src/CustomFieldDiscovery.php
+++ b/src/CustomFieldDiscovery.php
@@ -67,55 +67,7 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface {
 
     // Search for classes within all PSR-0 namespace locations.
     foreach ($this->getPluginNamespaces() as $namespace => $dirs) {
-      foreach ($dirs as $dir) {
-        if (file_exists($dir)) {
-          $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS)
-          );
-          foreach ($iterator as $fileinfo) {
-            if ($fileinfo->getExtension() == 'php') {
-              if ($cached = $this->fileCache->get($fileinfo->getPathName())) {
-                if (isset($cached['namespace'])) {
-                  // Explicitly unserialize this to create a new object instance.
-                  /** @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discovered */
-                  $discovered = unserialize($cached['content']);
-                  $definitions[$cached['service']][$cached['objectType']][$cached['namespace']] = $discovered;
-                }
-                continue;
-              }
-
-              $sub_path = $iterator->getSubIterator()->getSubPath();
-              $sub_path = $sub_path ? str_replace(DIRECTORY_SEPARATOR, '\\', $sub_path) . '\\' : '';
-              $class = $namespace . '\\' . $sub_path . $fileinfo->getBasename('.php');
-
-              // The filename is already known, so there is no need to find the
-              // file. However, StaticReflectionParser needs a finder, so use a
-              // mock version.
-              $finder = MockFileFinder::create($fileinfo->getPathName());
-              $parser = new StaticReflectionParser($class, $finder, TRUE);
-
-              /** @var $annotation \Lullabot\Mpx\DataService\Annotation\CustomField */
-              if ($annotation = $reader->getClassAnnotation($parser->getReflectionClass(), CustomField::class)) {
-                if (!is_subclass_of($class, CustomFieldInterface::class)) {
-                  throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
-                }
-
-                $discovered = new DiscoveredCustomField(
-                  $class, $annotation
-                );
-                $definitions[$annotation->service][$annotation->objectType][$annotation->namespace] = $discovered;
-
-                // Explicitly serialize this to create a new object instance.
-                $this->fileCache->set($fileinfo->getPathName(), ['service' => $annotation->service, 'objectType' => $annotation->objectType, 'namespace' => $annotation->namespace, 'content' => serialize($discovered)]);
-              }
-              else {
-                // Store a NULL object, so the file is not reparsed again.
-                $this->fileCache->set($fileinfo->getPathName(), [NULL]);
-              }
-            }
-          }
-        }
-      }
+      $this->getDefinitions($dirs, $definitions, $namespace, $reader);
     }
 
     // Don't let annotation loaders pile up.
@@ -147,6 +99,104 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface {
     }
 
     return $plugin_namespaces;
+  }
+
+  /**
+   * @param $dirs
+   * @param $definitions
+   * @param $namespace
+   * @param $reader
+   *
+   * @return mixed
+   */
+  private function getDefinitions($dirs, &$definitions, $namespace, $reader) {
+    foreach ($dirs as $dir) {
+      if (file_exists($dir)) {
+        $this->fetchFromDirectory($definitions, $namespace, $reader, $dir);
+      }
+    }
+  }
+
+  /**
+   * @param $definitions
+   * @param $namespace
+   * @param $reader
+   * @param $dir
+   */
+  private function fetchFromDirectory(&$definitions, $namespace, $reader, $dir) {
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $fileinfo) {
+      if ($fileinfo->getExtension() == 'php') {
+        $this->fetchFromFile($definitions, $namespace, $reader, $fileinfo, $iterator);
+      }
+    }
+  }
+
+  /**
+   * @param $definitions
+   * @param $namespace
+   * @param $reader
+   * @param $fileinfo
+   * @param $iterator
+   */
+  private function fetchFromFile(&$definitions, $namespace, $reader, $fileinfo, $iterator): void {
+    if ($cached = $this->fileCache->get($fileinfo->getPathName())) {
+      if (isset($cached['namespace'])) {
+        // Explicitly unserialize this to create a new object instance.
+        /** @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discovered */
+        $discovered = unserialize($cached['content']);
+        $definitions[$cached['service']][$cached['objectType']][$cached['namespace']] = $discovered;
+        return;
+      }
+    }
+
+    $class = $this->parseClassName($namespace, $fileinfo, $iterator);
+
+    // The filename is already known, so there is no need to find the
+    // file. However, StaticReflectionParser needs a finder, so use a
+    // mock version.
+    $finder = MockFileFinder::create($fileinfo->getPathName());
+    $parser = new StaticReflectionParser($class, $finder, TRUE);
+
+    /** @var $annotation \Lullabot\Mpx\DataService\Annotation\CustomField */
+    if (!$annotation = $reader->getClassAnnotation($parser->getReflectionClass(), CustomField::class)) {
+      // Store a NULL object, so the file is not reparsed again.
+      $this->fileCache->set($fileinfo->getPathName(), [NULL]);
+      return;
+    }
+
+    if (!is_subclass_of($class, CustomFieldInterface::class)) {
+      throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
+    }
+
+    $discovered = new DiscoveredCustomField(
+      $class, $annotation
+    );
+    $definitions[$annotation->service][$annotation->objectType][$annotation->namespace] = $discovered;
+
+    // Explicitly serialize this to create a new object instance.
+    $this->fileCache->set($fileinfo->getPathName(), [
+      'service' => $annotation->service,
+      'objectType' => $annotation->objectType,
+      'namespace' => $annotation->namespace,
+      'content' => serialize($discovered)
+    ]);
+  }
+
+  /**
+   * @param $namespace
+   * @param $fileinfo
+   * @param $iterator
+   *
+   * @return string
+   */
+  private function parseClassName($namespace, $fileinfo, $iterator): string {
+    $sub_path = $iterator->getSubIterator()->getSubPath();
+    $sub_path = $sub_path ? str_replace(DIRECTORY_SEPARATOR, '\\', $sub_path) . '\\' : '';
+    $class = $namespace . '\\' . $sub_path . $fileinfo->getBasename('.php');
+    return $class;
   }
 
 }

--- a/src/CustomFieldDiscovery.php
+++ b/src/CustomFieldDiscovery.php
@@ -50,12 +50,12 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface {
   }
 
   /**
-   * Returns all the Custom Fields
+   * Returns all the Custom Fields.
    *
-   * @return DiscoveredCustomField[] An array of all discovered data services, indexed by service name, object type, and namespace.
+   * @return \Lullabot\Mpx\DataService\DiscoveredCustomField[]
+   *   An array of all discovered data services, indexed by service name, object type, and namespace.
    */
-  public function getCustomFields(): array
-  {
+  public function getCustomFields(): array {
     $definitions = [];
 
     $reader = new AnnotationReader();
@@ -132,20 +132,21 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface {
   protected function getPluginNamespaces() {
     $plugin_namespaces = [];
     $namespaceSuffix = str_replace('/', '\\', '/Plugin/media_mpx/CustomField');
-      foreach ($this->rootNamespacesIterator as $namespace => $dirs) {
-        // Append the namespace suffix to the base namespace, to obtain the
-        // plugin namespace; for example, 'Drupal\Views' may become
-        // 'Drupal\Views\Plugin\Block'.
-        $namespace .= $namespaceSuffix;
-        foreach ((array) $dirs as $dir) {
-          // Append the directory suffix to the PSR-4 base directory, to obtain
-          // the directory where plugins are found. For example,
-          // DRUPAL_ROOT . '/core/modules/views/src' may become
-          // DRUPAL_ROOT . '/core/modules/views/src/Plugin/Block'.
-          $plugin_namespaces[$namespace][] = $dir . '/Plugin/media_mpx/CustomField';
-        }
+    foreach ($this->rootNamespacesIterator as $namespace => $dirs) {
+      // Append the namespace suffix to the base namespace, to obtain the
+      // plugin namespace; for example, 'Drupal\Views' may become
+      // 'Drupal\Views\Plugin\Block'.
+      $namespace .= $namespaceSuffix;
+      foreach ((array) $dirs as $dir) {
+        // Append the directory suffix to the PSR-4 base directory, to obtain
+        // the directory where plugins are found. For example,
+        // DRUPAL_ROOT . '/core/modules/views/src' may become
+        // DRUPAL_ROOT . '/core/modules/views/src/Plugin/Block'.
+        $plugin_namespaces[$namespace][] = $dir . '/Plugin/media_mpx/CustomField';
       }
+    }
 
     return $plugin_namespaces;
   }
+
 }

--- a/src/CustomFieldDiscovery.php
+++ b/src/CustomFieldDiscovery.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Reflection\StaticReflectionParser;
+use Drupal\Component\Annotation\Reflection\MockFileFinder;
+use Drupal\Component\FileCache\FileCacheFactory;
+use Drupal\Component\Utility\Crypt;
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+use Lullabot\Mpx\DataService\CustomFieldDiscoveryInterface;
+use Lullabot\Mpx\DataService\DiscoveredCustomField;
+
+/**
+ * Discovers custom field implementations in any enabled Drupal module.
+ *
+ * @see \Drupal\Component\Annotation\Plugin\Discovery\AnnotatedClassDiscovery
+ */
+class CustomFieldDiscovery implements CustomFieldDiscoveryInterface {
+
+  /**
+   * The possible plugin implementation namespaces.
+   *
+   * @var \Traversable
+   */
+  private $rootNamespacesIterator;
+
+  /**
+   * A cache (usually APC) for discovered annotations.
+   *
+   * @var \Drupal\Component\FileCache\FileCacheInterface
+   */
+  private $fileCache;
+
+  /**
+   * Constructs an AnnotatedClassDiscovery object.
+   *
+   * @param \Traversable $root_namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   */
+  public function __construct(\Traversable $root_namespaces) {
+    $this->rootNamespacesIterator = $root_namespaces;
+    $plugin_definition_annotation_name = CustomField::class;
+    $file_cache_suffix = str_replace('\\', '_', $plugin_definition_annotation_name);
+    $file_cache_suffix .= ':' . Crypt::hashBase64(serialize([]));
+    $this->fileCache = FileCacheFactory::get('annotation_discovery:' . $file_cache_suffix);
+  }
+
+  /**
+   * Returns all the Custom Fields
+   *
+   * @return DiscoveredCustomField[] An array of all discovered data services, indexed by service name, object type, and namespace.
+   */
+  public function getCustomFields(): array
+  {
+    $definitions = [];
+
+    $reader = new AnnotationReader();
+
+    // Clear the annotation loaders of any previous annotation classes.
+    AnnotationRegistry::reset();
+    // Register the namespaces of classes that can be used for annotations.
+    AnnotationRegistry::registerLoader('class_exists');
+
+    // Search for classes within all PSR-0 namespace locations.
+    foreach ($this->getPluginNamespaces() as $namespace => $dirs) {
+      foreach ($dirs as $dir) {
+        if (file_exists($dir)) {
+          $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS)
+          );
+          foreach ($iterator as $fileinfo) {
+            if ($fileinfo->getExtension() == 'php') {
+              if ($cached = $this->fileCache->get($fileinfo->getPathName())) {
+                if (isset($cached['namespace'])) {
+                  // Explicitly unserialize this to create a new object instance.
+                  /** @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discovered */
+                  $discovered = unserialize($cached['content']);
+                  $definitions[$cached['service']][$cached['objectType']][$cached['namespace']] = $discovered;
+                }
+                continue;
+              }
+
+              $sub_path = $iterator->getSubIterator()->getSubPath();
+              $sub_path = $sub_path ? str_replace(DIRECTORY_SEPARATOR, '\\', $sub_path) . '\\' : '';
+              $class = $namespace . '\\' . $sub_path . $fileinfo->getBasename('.php');
+
+              // The filename is already known, so there is no need to find the
+              // file. However, StaticReflectionParser needs a finder, so use a
+              // mock version.
+              $finder = MockFileFinder::create($fileinfo->getPathName());
+              $parser = new StaticReflectionParser($class, $finder, TRUE);
+
+              /** @var $annotation \Lullabot\Mpx\DataService\Annotation\CustomField */
+              if ($annotation = $reader->getClassAnnotation($parser->getReflectionClass(), CustomField::class)) {
+                if (!is_subclass_of($class, CustomFieldInterface::class)) {
+                  throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
+                }
+
+                $discovered = new DiscoveredCustomField(
+                  $class, $annotation
+                );
+                $definitions[$annotation->service][$annotation->objectType][$annotation->namespace] = $discovered;
+
+                // Explicitly serialize this to create a new object instance.
+                $this->fileCache->set($fileinfo->getPathName(), ['service' => $annotation->service, 'objectType' => $annotation->objectType, 'namespace' => $annotation->namespace, 'content' => serialize($discovered)]);
+              }
+              else {
+                // Store a NULL object, so the file is not reparsed again.
+                $this->fileCache->set($fileinfo->getPathName(), [NULL]);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Don't let annotation loaders pile up.
+    AnnotationRegistry::reset();
+
+    return $definitions;
+  }
+
+  /**
+   * Return an array of possible plugin namespaces.
+   *
+   * @return array
+   */
+  protected function getPluginNamespaces() {
+    $plugin_namespaces = [];
+    $namespaceSuffix = str_replace('/', '\\', '/Plugin/media_mpx/CustomField');
+      foreach ($this->rootNamespacesIterator as $namespace => $dirs) {
+        // Append the namespace suffix to the base namespace, to obtain the
+        // plugin namespace; for example, 'Drupal\Views' may become
+        // 'Drupal\Views\Plugin\Block'.
+        $namespace .= $namespaceSuffix;
+        foreach ((array) $dirs as $dir) {
+          // Append the directory suffix to the PSR-4 base directory, to obtain
+          // the directory where plugins are found. For example,
+          // DRUPAL_ROOT . '/core/modules/views/src' may become
+          // DRUPAL_ROOT . '/core/modules/views/src/Plugin/Block'.
+          $plugin_namespaces[$namespace][] = $dir . '/Plugin/media_mpx/CustomField';
+        }
+      }
+
+    return $plugin_namespaces;
+  }
+}

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -8,7 +8,6 @@ use Drupal\media\MediaInterface;
 use Drupal\media\MediaSourceInterface;
 use GuzzleHttp\Exception\TransferException;
 use Lullabot\Mpx\DataService\Media\Media as MpxMedia;
-use Psr\Http\Message\UriInterface;
 
 /**
  * Media source for mpx Media items.

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -80,10 +80,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
 
     $service_info = $this->getPluginDefinition()['media_mpx'];
     $fields = $this->customFieldManager->getCustomFields();
-    /**
-     * @var string $namespace
-     * @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField
-     */
+    /* @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField */
     $service_name = $service_info['service_name'];
     $object_type = $service_info['object_type'];
     if (isset($fields[$service_name]) && isset($fields[$service_name][$object_type]) && $var = $fields[$service_name][$object_type]) {
@@ -110,7 +107,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
    * @param string $class
    *   The custom field class implementation name.
    */
-  private function addProperties(&$metadata, $namespace, $properties, $class) {
+  private function addProperties(array &$metadata, string $namespace, array $properties, string $class) {
     foreach ($properties as $property) {
       $label = $this->propertyLabel($namespace, $property, $class);
 
@@ -171,6 +168,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
    *   The media item to return the source field definition for.
    *
    * @return \Drupal\Core\Field\FieldDefinitionInterface|null
+   *   The source field definition, if one exists.
    */
   private function sourceField(MediaInterface $media) {
     /** @var \Drupal\media\MediaTypeInterface $media_type */
@@ -183,7 +181,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
    * Return the mpx metadata for a given attribute on a media entity.
    *
    * @param \Drupal\media\MediaInterface $media
-   *   The media entity to return metdata for.
+   *   The media entity to return metadata for.
    * @param string $attribute_name
    *   The mpx field or property name.
    *
@@ -243,7 +241,8 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
       }
 
       return $local_uri;
-    } catch (TransferException $e) {
+    }
+    catch (TransferException $e) {
       /** @var \Lullabot\Mpx\DataService\Media\Media $mpx_media */
       $mpx_media = $this->getMpxObject($media);
       // @todo Can this somehow deeplink to the mpx console?
@@ -286,23 +285,20 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
    *
    * @param \Drupal\media\MediaInterface $media
    *   The media entity being processed.
-   * @param $attribute_name
+   * @param string $attribute_name
    *   The attribute of the field.
    *
    * @return mixed|null
    *   The metadata value or NULL if one is not found.
    */
-  private function getCustomFieldsMetadata(MediaInterface $media, $attribute_name) {
+  private function getCustomFieldsMetadata(MediaInterface $media, string $attribute_name) {
     // Now check for custom fields.
     $service_info = $this->getPluginDefinition()['media_mpx'];
     $fields = $this->customFieldManager->getCustomFields();
     $properties = [];
 
     // First, we extract all possible custom fields that may be defined.
-    /**
-     * @var string $namespace
-     * @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField
-     */
+    /* @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField */
     foreach ($fields[$service_info['service_name']][$service_info['object_type']] as $namespace => $discoveredCustomField) {
       $class = $discoveredCustomField->getClass();
       $namespace = $discoveredCustomField->getAnnotation()->namespace;

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -200,20 +200,22 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
      * @var string $namespace
      * @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField
      */
-    foreach ($fields[$service_info['service_name']][$service_info['object_type']] as $namespace => $discoveredCustomField) {
-      $class = $discoveredCustomField->getClass();
-      $namespace = $discoveredCustomField->getAnnotation()->namespace;
-      foreach ($this->propertyExtractor()->getProperties($class) as $property) {
-        $label = sprintf('%s:%s', $namespace, $property);
-        if ($shortDescription = $this->propertyExtractor()
-          ->getShortDescription($class, $property)) {
-          $label = $shortDescription . ' (' . $label . ')';
-        }
+    if ($var = $fields[$service_info['service_name']][$service_info['object_type']]) {
+      foreach ($var as $namespace => $discoveredCustomField) {
+        $class = $discoveredCustomField->getClass();
+        $namespace = $discoveredCustomField->getAnnotation()->namespace;
+        foreach ($this->propertyExtractor()->getProperties($class) as $property) {
+          $label = sprintf('%s:%s', $namespace, $property);
+          if ($shortDescription = $this->propertyExtractor()
+            ->getShortDescription($class, $property)) {
+            $label = $shortDescription . ' (' . $label . ')';
+          }
 
-        // The config system does not allow periods in values, so we encode
-        // those using URL rules.
-        $key = str_replace('.', '%2E', $namespace) . '/' . $property;
-        $metadata[$key] = $label;
+          // The config system does not allow periods in values, so we encode
+          // those using URL rules.
+          $key = str_replace('.', '%2E', $namespace) . '/' . $property;
+          $metadata[$key] = $label;
+        }
       }
     }
 
@@ -234,8 +236,8 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
   private function extractNamespaceField($attribute_name): array {
     $decoded = str_replace('%2E', '.', $attribute_name);
     $parts = explode('/', $decoded);
-    $namespace = implode('/', $parts);
     $field = array_pop($parts);
+    $namespace = implode('/', $parts);
     return [$namespace, $field];
   }
 

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -262,6 +262,16 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
       return $this->getReflectedProperty($media, $attribute_name, $mpx_media);
     }
 
+    return $this->getCustomFieldsMetdata($media, $attribute_name);
+  }
+
+  /**
+   * @param \Drupal\media\MediaInterface $media
+   * @param $attribute_name
+   *
+   * @return mixed|null|string
+   */
+  private function getCustomFieldsMetdata(MediaInterface $media, $attribute_name) {
     // Now check for custom fields.
     $service_info = $this->getPluginDefinition()['media_mpx'];
     $fields = $this->customFieldManager->getCustomFields();

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -84,7 +84,9 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
      * @var string $namespace
      * @var \Lullabot\Mpx\DataService\DiscoveredCustomField $discoveredCustomField
      */
-    if ($var = $fields[$service_info['service_name']][$service_info['object_type']]) {
+    $service_name = $service_info['service_name'];
+    $object_type = $service_info['object_type'];
+    if (isset($fields[$service_name]) && isset($fields[$service_name][$object_type]) && $var = $fields[$service_name][$object_type]) {
       foreach ($var as $namespace => $discoveredCustomField) {
         $class = $discoveredCustomField->getClass();
         $namespace = $discoveredCustomField->getAnnotation()->namespace;

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -51,9 +51,9 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
 
     $metadata = [];
     foreach ($extractor->getProperties(MpxMedia::class) as $property) {
-      $label = sprintf('(%s)', $property);
+      $label = $property;
       if ($shortDescription = $extractor->getShortDescription(MpxMedia::class, $property)) {
-        $label = $shortDescription . ' ' . $label;
+        $label = $shortDescription . ' (' . $label . ')';
       }
       $metadata[$property] = $label;
     }
@@ -68,9 +68,9 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
       $class = $discoveredCustomField->getClass();
       $namespace = $discoveredCustomField->getAnnotation()->namespace;
       foreach ($extractor->getProperties($class) as $property) {
-        $label = sprintf('(%s:%s)', $namespace, $property);
+        $label = sprintf('%s:%s', $namespace, $property);
         if ($shortDescription = $extractor->getShortDescription($class, $property)) {
-          $label = $shortDescription . ' ' . $label;
+          $label = $shortDescription . ' (' . $label . ')';
         }
         $metadata[str_replace('.', '%2E', $namespace) . '/' . $property] = $label;
       }

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -16,6 +16,7 @@ use Drupal\media_mpx\DataObjectFactoryCreator;
 use Drupal\media_mpx\Entity\Account;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\CachingPhpDocExtractor;
 use Lullabot\Mpx\DataService\CustomFieldManager;
 use Lullabot\Mpx\DataService\ObjectInterface;
 use Psr\Log\LoggerInterface;
@@ -215,8 +216,7 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
    *   An array of property values and their descriptions.
    */
   protected function propertyExtractor(): PropertyInfoExtractorInterface {
-    // @todo Cache this!
-    $phpDocExtractor = new PhpDocExtractor();
+    $phpDocExtractor = new CachingPhpDocExtractor();
     $reflectionExtractor = new ReflectionExtractor();
 
     $listExtractors = [$reflectionExtractor];

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -21,7 +21,6 @@ use Lullabot\Mpx\DataService\CustomFieldManager;
 use Lullabot\Mpx\DataService\ObjectInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -60,6 +60,8 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
   protected $logger;
 
   /**
+   * The manager used to load custom field implementations.
+   *
    * @var \Lullabot\Mpx\DataService\CustomFieldManager
    */
   protected $customFieldManager;

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -246,16 +246,16 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
    *   The media entity being accessed.
    * @param string $attribute_name
    *   The metadata attribute being accessed.
-   * @param mixed $mpx_object
-   *   The mpx object.
    *
    * @return mixed|null
    *   Metadata attribute value or NULL if unavailable.
    */
-  protected function getReflectedProperty(MediaInterface $media, string $attribute_name, $mpx_object) {
+  protected function getReflectedProperty(MediaInterface $media, string $attribute_name) {
     $method = 'get' . ucfirst($attribute_name);
     // @todo At the least this should be a static cache tied to $media.
     try {
+      /** @var \Lullabot\Mpx\DataService\Media\Media $mpx_object */
+      $mpx_object = $this->getMpxObject($media);
       $value = $mpx_object->$method();
     }
     catch (\TypeError $e) {

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -91,6 +91,8 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
    *   The HTTP client used to download thumbnails.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger used to log errors while downloading thumbnails.
+   * @param \Lullabot\Mpx\DataService\CustomFieldManager $customFieldManager
+   *   The manager used to load custom field classes.
    */
   public function __construct(array $configuration, string $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, FieldTypePluginManagerInterface $field_type_manager, ConfigFactoryInterface $config_factory, KeyValueFactoryInterface $keyValueFactory, DataObjectFactoryCreator $dataObjectFactory, ClientInterface $httpClient, LoggerInterface $logger, CustomFieldManager $customFieldManager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $entity_field_manager, $field_type_manager, $config_factory);

--- a/src/Plugin/media/Source/Player.php
+++ b/src/Plugin/media/Source/Player.php
@@ -33,11 +33,11 @@ class Player extends MediaSourceBase implements MediaSourceInterface {
    * {@inheritdoc}
    */
   public function getMetadataAttributes() {
-    list($propertyInfo, $properties) = $this->extractMediaProperties(MpxPlayer::class);
+    $extractor = $this->propertyExtractor();
 
     $metadata = [];
-    foreach ($properties as $property) {
-      $metadata[$property] = $propertyInfo->getShortDescription(MpxPlayer::class, $property);
+    foreach ($extractor->getProperties(MpxPlayer::class) as $property) {
+      $metadata[$property] = $extractor->getShortDescription(MpxPlayer::class, $property);
     }
 
     return $metadata;
@@ -52,9 +52,10 @@ class Player extends MediaSourceBase implements MediaSourceInterface {
     $media_type = $this->entityTypeManager->getStorage('media_type')->load($media->bundle());
     $source_field = $this->getSourceFieldDefinition($media_type);
     if (!$media->get($source_field->getName())->isEmpty()) {
-      list(, $properties) = $this->extractMediaProperties(MpxPlayer::class);
+      $extractor = $this->propertyExtractor();
 
-      if (in_array($attribute_name, $properties)) {
+
+      if (in_array($attribute_name, $extractor->getProperties(MpxPlayer::class))) {
         return $this->getReflectedProperty($media, $attribute_name, $this->getMpxObject($media));
       }
     };

--- a/src/Plugin/media/Source/Player.php
+++ b/src/Plugin/media/Source/Player.php
@@ -54,7 +54,6 @@ class Player extends MediaSourceBase implements MediaSourceInterface {
     if (!$media->get($source_field->getName())->isEmpty()) {
       $extractor = $this->propertyExtractor();
 
-
       if (in_array($attribute_name, $extractor->getProperties(MpxPlayer::class))) {
         return $this->getReflectedProperty($media, $attribute_name, $this->getMpxObject($media));
       }

--- a/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
+++ b/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\media_mpx_test\Plugin\media_mpx\CustomField;
 
-use Lullabot\Mpx\DataService\Annotation\CustomField;
 use Lullabot\Mpx\DataService\CustomFieldInterface;
 
 /**
@@ -34,4 +33,5 @@ class MockCustomField implements CustomFieldInterface {
   public function setSeries(string $series) {
     $this->series = $series;
   }
+
 }

--- a/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
+++ b/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\media_mpx_test\Plugin\media_mpx\CustomField;
 
+use Lullabot\Mpx\DataService\Annotation\CustomField;
 use Lullabot\Mpx\DataService\CustomFieldInterface;
 
 /**

--- a/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
+++ b/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
@@ -22,14 +22,20 @@ class MockCustomField implements CustomFieldInterface {
   protected $series;
 
   /**
+   * Return the series the Media object belongs to.
+   *
    * @return string
+   *   The series name.
    */
   public function getSeries(): string {
     return $this->series;
   }
 
   /**
+   * Set the series.
+   *
    * @param string $series
+   *   The series to set.
    */
   public function setSeries(string $series) {
     $this->series = $series;

--- a/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
+++ b/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\media_mpx_test\Plugin\media_mpx\CustomField;
+
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+
+/**
+ * @CustomField(
+ *   namespace="http://xml.example.com",
+ *   service="Media Data Service",
+ *   objectType="Media",
+ * )
+ */
+class MockCustomField implements CustomFieldInterface {
+
+  /**
+   * The name of the series.
+   *
+   * @var string
+   */
+  protected $series;
+
+  /**
+   * @return string
+   */
+  public function getSeries(): string {
+    return $this->series;
+  }
+
+  /**
+   * @param string $series
+   */
+  public function setSeries(string $series) {
+    $this->series = $series;
+  }
+}

--- a/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
+++ b/test_modules/media_mpx_test/src/Plugin/media_mpx/CustomField/MockCustomField.php
@@ -2,10 +2,14 @@
 
 namespace Drupal\media_mpx_test\Plugin\media_mpx\CustomField;
 
+// @codingStandardsIgnoreStart
 use Lullabot\Mpx\DataService\Annotation\CustomField;
+// @codingStandardsIgnoreEnd
 use Lullabot\Mpx\DataService\CustomFieldInterface;
 
 /**
+ * A mock custom field implementation containing a series.
+ *
  * @CustomField(
  *   namespace="http://xml.example.com",
  *   service="Media Data Service",

--- a/tests/fixtures/media-object.json
+++ b/tests/fixtures/media-object.json
@@ -1,4 +1,7 @@
 {
+  "$xmlns": {
+    "prefix1": "http://xml.example.com"
+  },
   "id": "http://data.media.theplatform.com/media/data/Media/2602559",
   "guid": "zYO7XMrWyix_9UCMurLYEWJPrWYHavMM",
   "title": "thePlatform's History",
@@ -358,5 +361,6 @@
   "fileSourceMediaId": "http://example.com/reserved-for-future-use",
   "originalMediaIds": [
     "http://example.com/media-url"
-  ]
+  ],
+  "prefix1$series": "The Adventures of Pixel the Cat"
 }

--- a/tests/src/FunctionalJavascript/CustomFieldMapTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldMapTest.php
@@ -25,6 +25,12 @@ class CustomFieldMapTest extends JavascriptTestBase {
   ];
 
   /**
+   * Tests mapping a custom field.
+   *
+   * This test:
+   *   - Relies on a custom field defined in media_mpx_test.
+   *   - Validates the UI for mapping a custom field.
+   *   - Validates saving an mpx media entity and that the field is visible.
    */
   public function testMapCustomField() {
     /** @var \Drupal\media_mpx_test\MockClientFactory $factory */

--- a/tests/src/FunctionalJavascript/CustomFieldMapTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldMapTest.php
@@ -9,6 +9,11 @@ use Drupal\media_mpx\Entity\Account;
 use Drupal\media_mpx\Entity\User;
 use Drupal\media_mpx_test\JsonResponse;
 
+/**
+ * Tests mapping a custom mpx field to a Drupal field.
+ *
+ * @group media_mpx
+ */
 class CustomFieldMapTest extends JavascriptTestBase {
 
   protected $minkDefaultDriverClass = DrupalSelenium2Driver::class;
@@ -26,7 +31,6 @@ class CustomFieldMapTest extends JavascriptTestBase {
     $factory = $this->container->get('media_mpx.client_factory');
     $factory->getMockHandler()->append([
       new JsonResponse(200, [], 'signin-success.json'),
-//      new JsonResponse(200, [], 'resolveDomain.json'),
       new JsonResponse(200, [], 'media-object.json'),
     ]);
 

--- a/tests/src/FunctionalJavascript/CustomFieldMapTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldMapTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
+use Drupal\FunctionalJavascriptTests\JavascriptTestBase;
+use Drupal\media\Entity\MediaType;
+use Drupal\media_mpx\Entity\Account;
+use Drupal\media_mpx\Entity\User;
+use Drupal\media_mpx_test\JsonResponse;
+
+class CustomFieldMapTest extends JavascriptTestBase {
+
+  protected $minkDefaultDriverClass = DrupalSelenium2Driver::class;
+
+  protected static $modules = [
+    'media_mpx',
+    'media_mpx_test',
+    'field_ui',
+  ];
+
+  /**
+   */
+  public function testMapCustomField() {
+    /** @var \Drupal\media_mpx_test\MockClientFactory $factory */
+    $factory = $this->container->get('media_mpx.client_factory');
+    $factory->getMockHandler()->append([
+      new JsonResponse(200, [], 'signin-success.json'),
+//      new JsonResponse(200, [], 'resolveDomain.json'),
+      new JsonResponse(200, [], 'media-object.json'),
+    ]);
+
+    $user = User::create([
+      'label' => 'JavaScript test user',
+      'id' => 'mpx_testing_example_com',
+      'username' => 'mpx/testing@example.com',
+      'password' => 'SECRET',
+    ]);
+    $user->save();
+    $account = Account::create([
+      'label' => 'JavaScript test account',
+      'id' => 'mpx_account',
+      'user' => $user->id(),
+      'account' => 'http://example.com/account/1',
+      'public_id' => 'public-id',
+    ]);
+    $account->save();
+
+    /** @var \Drupal\media\MediaTypeInterface $media_type */
+    $media_type = MediaType::create([
+      'id' => 'mpx',
+      'label' => 'mpx media type',
+      'source' => 'media_mpx_media',
+    ]);
+    $media_type->save();
+    $source_field = $media_type->getSource()->createSourceField($media_type);
+    $source_field->getFieldStorageDefinition()->save();
+    $source_field->save();
+
+    // This saves us having to mock thumbnail http requests.
+    $media_type->setQueueThumbnailDownloadsStatus(TRUE);
+    $media_type
+      ->set('source_configuration', [
+        'source_field' => $source_field->getName(),
+        'account' => $account->id(),
+      ])
+      ->save();
+
+    // Add the new field to the default form and view displays for this
+    // media type.
+    if ($source_field->isDisplayConfigurable('form')) {
+      // @todo Replace entity_get_form_display() when #2367933 is done.
+      // https://www.drupal.org/node/2872159.
+      $display = entity_get_form_display('media', $media_type->id(), 'default');
+      $media_type->getSource()->prepareFormDisplay($media_type, $display);
+      $display->save();
+    }
+    if ($source_field->isDisplayConfigurable('view')) {
+      // @todo Replace entity_get_display() when #2367933 is done.
+      // https://www.drupal.org/node/2872159.
+      $display = entity_get_display('media', $media_type->id(), 'default');
+      $media_type->getSource()->prepareViewDisplay($media_type, $display);
+      $display->save();
+    }
+
+    $storage = $this->container->get('entity_type.manager')
+      ->getStorage('field_storage_config')
+      ->create([
+        'entity_type' => 'media',
+        'field_name' => 'field_series',
+        'type' => 'string',
+      ]);
+    $storage->save();
+    $series = $this->container->get('entity_type.manager')
+      ->getStorage('field_config')
+      ->create([
+        'field_storage' => $storage,
+        'bundle' => 'mpx',
+        'label' => 'Series custom field',
+        'required' => FALSE,
+      ]);
+    $series->save();
+
+    $display = entity_get_display('media', $media_type->id(), 'default');
+    $display->setComponent('field_series');
+    $display->save();
+
+    $this->drupalLogin($this->rootUser);
+
+    $this->drupalGet('admin/structure/media/manage/mpx');
+    $this->getSession()->getPage()->selectFieldOption('The name of the series. (http://xml.example.com:series)', 'field_series');
+    $this->click('#edit-submit');
+    $this->drupalGet('/media/add/mpx');
+    $this->getSession()->getPage()->fillField('Name', $this->randomString());
+    $this->getSession()->getPage()->fillField('mpx Media', 'http://data.media.theplatform.com/media/data/Media/2602559');
+    $this->click('#edit-submit');
+
+    $this->assertSession()->responseContains("The Adventures of Pixel the Cat");
+  }
+
+}


### PR DESCRIPTION
See the changes in the README for details for custom module implementations. The test module should provide a good example of how this works. The discovery class was mostly copied from AnnotatedClassDiscovery in core, but significantly refactored because that class is painfully complex.