### PR TITLE
Validate credentials and handle mpx connection errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "^0.1.1",
+    "lullabot/mpx-php": "^0.2.0",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4"
   },

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -25,6 +25,14 @@ services:
     class: Drupal\media_mpx\NotificationListener
     arguments: ['@media_mpx.authenticated_client_factory', '@media_mpx.data_service_manager', '@state', '@logger.channel.media_mpx']
 
+  logger.channel.media_mpx:
+    parent: logger.channel_base
+    arguments: ['media_mpx']
+
+  media_mpx.exception_logger:
+    class: Drupal\media_mpx\MpxLogger
+    arguments: ['@logger.channel.media_mpx']
+
   # We need to define our own handler stack instance separate from Drupal
   # core's. Otherwise, when we add the mpx_errors handler, it gets applied to
   # all HTTP requests, and not just those sent to mpx.
@@ -48,10 +56,6 @@ services:
   media_mpx.client_factory:
     class: Drupal\media_mpx\ClientFactory
     arguments: ['@media_mpx.http_handler_stack', '@http_client_factory']
-
-  logger.channel.media_mpx:
-    parent: logger.channel_base
-    arguments: ['media_mpx']
 
   # These services are "internal" and generally not needed by custom code.
   media_mpx.session_lock:

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -77,4 +77,18 @@ class User extends ConfigEntityBase implements UserInterface {
     return $this->password;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getMpxUsername() {
+    return $this->getUsername();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMpxPassword() {
+    return $this->getPassword();
+  }
+
 }

--- a/src/Entity/UserInterface.php
+++ b/src/Entity/UserInterface.php
@@ -3,11 +3,12 @@
 namespace Drupal\media_mpx\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Lullabot\Mpx\Service\IdentityManagement\UserInterface as MpxUserInterface;
 
 /**
  * Provides an interface for defining mpx User entities.
  */
-interface UserInterface extends ConfigEntityInterface {
+interface UserInterface extends ConfigEntityInterface, MpxUserInterface {
 
   /**
    * Return the mpx username.

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -11,7 +11,6 @@ use Drupal\media_mpx\MpxLogger;
 use GuzzleHttp\Exception\TransferException;
 use Lullabot\Mpx\DataService\ByFields;
 use Lullabot\Mpx\Exception\ClientException;
-use Lullabot\Mpx\Exception\MpxExceptionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -36,6 +35,8 @@ class AccountForm extends EntityForm {
   protected $dataObjectFactory;
 
   /**
+   * The system logger for mpx errors.
+   *
    * @var \Drupal\media_mpx\MpxLogger
    */
   private $mpxLogger;
@@ -47,6 +48,8 @@ class AccountForm extends EntityForm {
    *   The current path service.
    * @param \Drupal\media_mpx\DataObjectFactoryCreator $dataObjectFactory
    *   The factory used to load mpx objects.
+   * @param \Drupal\media_mpx\MpxLogger $mpxLogger
+   *   The system logger for mpx errors.
    */
   public function __construct(CurrentPathStack $currentPathStack, DataObjectFactoryCreator $dataObjectFactory, MpxLogger $mpxLogger) {
     $this->currentPathStack = $currentPathStack;

--- a/src/Form/AccountForm.php
+++ b/src/Form/AccountForm.php
@@ -111,19 +111,8 @@ class AccountForm extends EntityForm {
         list($options, $account_pids) = $this->accountOptions($form_state);
       }
       catch (ClientException $e) {
-        // First, we have special handling for credential errors.
-        if ($e->getCode() == 401 || $e->getCode() == 403) {
-          $this->messenger()->addError($this->t('Access was denied connecting to mpx. %error',
-            [
-              '%error' => $e->getMessage(),
-            ])
-          );
-          return [];
-        }
-
-        // This is a client exception, but not an authentication error so we
-        // throw this up to the "unexpected error" case.
-        throw $e;
+        $this->displayCredentialError($e);
+        return [];
       }
     }
     catch (TransferException $e) {
@@ -297,6 +286,28 @@ class AccountForm extends EntityForm {
       $account_pids[(string) $account->getId()] = $account->getPid();
     }
     return [$options, $account_pids];
+  }
+
+  /**
+   * Display an access denied error.
+   *
+   * @param \Lullabot\Mpx\Exception\ClientException $e
+   *   The mpx client exception.
+   */
+  private function displayCredentialError(ClientException $e) {
+    // First, we have special handling for credential errors.
+    if ($e->getCode() == 401 || $e->getCode() == 403) {
+      $this->messenger()->addError($this->t('Access was denied connecting to mpx. %error',
+        [
+          '%error' => $e->getMessage(),
+        ])
+      );
+      return;
+    }
+
+    // This is a client exception, but not an authentication error so we
+    // throw this up to the "unexpected error" case.
+    throw $e;
   }
 
 }

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -4,11 +4,60 @@ namespace Drupal\media_mpx\Form;
 
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\media_mpx\MpxLogger;
+use Drupal\media_mpx\UserSessionFactory;
+use GuzzleHttp\Exception\TransferException;
+use Lullabot\Mpx\Exception\ClientException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class UserForm.
  */
 class UserForm extends EntityForm {
+
+  /**
+   * The user being edited.
+   *
+   * @var \Drupal\media_mpx\Entity\UserInterface
+   */
+  protected $entity;
+
+  /**
+   * The factory used to test user credentials.
+   *
+   * @var \Drupal\media_mpx\UserSessionFactory
+   */
+  protected $userSessionFactory;
+
+  /**
+   * The logger for unhandled mpx errors.
+   *
+   * @var \Drupal\media_mpx\MpxLogger
+   */
+  protected $mpxLogger;
+
+  /**
+   * UserForm constructor.
+   *
+   * @param \Drupal\media_mpx\UserSessionFactory $userSessionFactory
+   *   The factory used to test user credentials.
+   * @param \Drupal\media_mpx\MpxLogger $mpxLogger
+   *   The logger for unhandled mpx errors.
+   */
+  public function __construct(UserSessionFactory $userSessionFactory, MpxLogger $mpxLogger) {
+    $this->userSessionFactory = $userSessionFactory;
+    $this->mpxLogger = $mpxLogger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('media_mpx.user_session_factory'),
+      $container->get('media_mpx.exception_logger')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -24,7 +73,9 @@ class UserForm extends EntityForm {
       '#title' => $this->t('mpx user name'),
       '#maxlength' => 255,
       '#default_value' => $media_mpx_user->label(),
-      '#description' => $this->t("The MPX user name."),
+      '#description' => $this->t('The MPX user name. Typically, this is an email address. See the <a href="@user-docs">user setup documentation</a> for more details.', [
+        '@user-docs' => 'https://docs.theplatform.com/help/setting-up-new-mpx-users',
+      ]),
       '#required' => TRUE,
     ];
 
@@ -41,7 +92,7 @@ class UserForm extends EntityForm {
     $form['password'] = [
       '#type' => 'password',
       '#title' => $this->t('mpx password'),
-      '#description' => $this->t('The mpx user password.'),
+      '#description' => $this->t('The mpx user password. This can be blank if the password is set through settings.php.'),
     ];
 
     return $form;
@@ -50,23 +101,77 @@ class UserForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $this->addMpxDirectory();
+
+    if (empty($this->entity->getPassword())) {
+      $this->messenger()->addWarning($this->t('The mpx user credentials were not validated as no password was specified. This is expected if passwords are being injected through settings.php.'));
+      return;
+    }
+
+    $session = $this->userSessionFactory->fromUser($this->entity);
+    try {
+      try {
+        $session->acquireToken(1);
+      }
+      catch (ClientException $e) {
+        if ($e->getCode() == 401 || $e->getCode() == 403) {
+          $form_state->setError($form, $this->t('Access was denied connecting to mpx. @error',
+            [
+              '@error' => $e->getMessage(),
+            ])
+          );
+          return;
+        }
+        throw $e;
+      }
+    }
+    catch (TransferException $e) {
+      $form_state->setError($form, $this->t('An error occurred connecting to mpx. The full error has been logged. @error',
+        [
+          '@error' => $e->getMessage(),
+        ])
+      );
+      $this->mpxLogger->logException($e);
+      return;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save(array $form, FormStateInterface $form_state) {
-    $media_mpx_user = $this->entity;
-    $status = $media_mpx_user->save();
+    $this->addMpxDirectory();
+    $status = $this->entity->save();
 
     switch ($status) {
       case SAVED_NEW:
         $this->messenger()->addStatus($this->t('Created the %label mpx User.', [
-          '%label' => $media_mpx_user->label(),
+          '%label' => $this->entity->label(),
         ]));
         break;
 
       default:
         $this->messenger()->addStatus($this->t('Saved the %label mpx User.', [
-          '%label' => $media_mpx_user->label(),
+          '%label' => $this->entity->label(),
         ]));
     }
-    $form_state->setRedirectUrl($media_mpx_user->toUrl('collection'));
+    $form_state->setRedirectUrl($this->entity->toUrl('collection'));
+  }
+
+  /**
+   * Set an mpx directory on the username if one is not specified.
+   *
+   * By default mpx accounts are in the 'mpx' directory. Only legacy accounts
+   * are in other directories. If no directory is specified, add it
+   * automatically.
+   */
+  private function addMpxDirectory() {
+    if (strpos($this->entity->getUsername(), '/') === FALSE) {
+      $this->entity->set('username', 'mpx/' . $this->entity->getUsername());
+    }
   }
 
 }

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -181,7 +181,6 @@ class UserForm extends EntityForm {
         ])
       );
       $this->mpxLogger->logException($e);
-      return;
     }
   }
 

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -111,32 +111,7 @@ class UserForm extends EntityForm {
       return;
     }
 
-    $session = $this->userSessionFactory->fromUser($this->entity);
-    try {
-      try {
-        $session->acquireToken(1);
-      }
-      catch (ClientException $e) {
-        if ($e->getCode() == 401 || $e->getCode() == 403) {
-          $form_state->setError($form, $this->t('Access was denied connecting to mpx. @error',
-            [
-              '@error' => $e->getMessage(),
-            ])
-          );
-          return;
-        }
-        throw $e;
-      }
-    }
-    catch (TransferException $e) {
-      $form_state->setError($form, $this->t('An error occurred connecting to mpx. The full error has been logged. @error',
-        [
-          '@error' => $e->getMessage(),
-        ])
-      );
-      $this->mpxLogger->logException($e);
-      return;
-    }
+    $this->validateMpxCredentials($form, $form_state);
   }
 
   /**
@@ -171,6 +146,43 @@ class UserForm extends EntityForm {
   private function addMpxDirectory() {
     if (strpos($this->entity->getUsername(), '/') === FALSE) {
       $this->entity->set('username', 'mpx/' . $this->entity->getUsername());
+    }
+  }
+
+  /**
+   * Validate the mpx username and password.
+   *
+   * @param array &$form
+   *   The settings form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  private function validateMpxCredentials(array &$form, FormStateInterface $form_state) {
+    $session = $this->userSessionFactory->fromUser($this->entity);
+    try {
+      try {
+        $session->acquireToken(1);
+      }
+      catch (ClientException $e) {
+        if ($e->getCode() == 401 || $e->getCode() == 403) {
+          $form_state->setError($form, $this->t('Access was denied connecting to mpx. @error',
+            [
+              '@error' => $e->getMessage(),
+            ])
+          );
+          return;
+        }
+        throw $e;
+      }
+    }
+    catch (TransferException $e) {
+      $form_state->setError($form, $this->t('An error occurred connecting to mpx. The full error has been logged. @error',
+        [
+          '@error' => $e->getMessage(),
+        ])
+      );
+      $this->mpxLogger->logException($e);
+      return;
     }
   }
 

--- a/src/Form/UserForm.php
+++ b/src/Form/UserForm.php
@@ -65,14 +65,13 @@ class UserForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
 
-    $media_mpx_user = $this->entity;
     // @todo Email validation.
     // @todo html5 placeholder
     $form['username'] = [
       '#type' => 'textfield',
       '#title' => $this->t('mpx user name'),
       '#maxlength' => 255,
-      '#default_value' => $media_mpx_user->label(),
+      '#default_value' => $this->entity->label(),
       '#description' => $this->t('The MPX user name. Typically, this is an email address. See the <a href="@user-docs">user setup documentation</a> for more details.', [
         '@user-docs' => 'https://docs.theplatform.com/help/setting-up-new-mpx-users',
       ]),
@@ -81,12 +80,12 @@ class UserForm extends EntityForm {
 
     $form['id'] = [
       '#type' => 'machine_name',
-      '#default_value' => $media_mpx_user->id(),
+      '#default_value' => $this->entity->id(),
       '#machine_name' => [
         'exists' => '\Drupal\media_mpx\Entity\User::load',
         'source' => ['username'],
       ],
-      '#disabled' => !$media_mpx_user->isNew(),
+      '#disabled' => !$this->entity->isNew(),
     ];
 
     $form['password'] = [

--- a/src/MpxLogger.php
+++ b/src/MpxLogger.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\Core\Utility\Error;
+use GuzzleHttp\Exception\TransferException;
+use Lullabot\Mpx\Exception\MpxExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Utility class for logging mpx errors.
+ *
+ * In general, this should only be used for errors that are unexpected. For
+ * example, the user / password form has it's own error handling for invalid
+ * credentials, but calls this class on other types of exceptions.
+ */
+class MpxLogger {
+
+  /**
+   * The system logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * MpxLogger constructor.
+   *
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The system logger.
+   */
+  public function __construct(LoggerInterface $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * Log an mpx exception.
+   *
+   * @param \GuzzleHttp\Exception\TransferException $exception
+   *   The exception that is going to be logged.
+   * @param int $severity
+   *   The severity of the message, as per RFC 3164.
+   * @param string $link
+   *   A link to associate with the message.
+   */
+  public function logException(TransferException $exception, $severity = RfcLogLevel::ERROR, $link = NULL) {
+    if (!($exception instanceof MpxExceptionInterface)) {
+      $this->watchdogException($exception, NULL, [], $severity, $link);
+      return;
+    }
+
+    $message = 'HTTP %code %title %description %correlation_id %type in %function (line %line of %file).';
+    $variables = [
+      '%code' => $exception->getCode(),
+      '%title' => $exception->getTitle(),
+      '%description' => $exception->getDescription(),
+      '%correlation_id' => $exception->getCorrelationId(),
+    ];
+    $this->watchdogException($exception, $message, $variables, $severity, $link);
+  }
+
+  /**
+   * Logs an exception.
+   *
+   * @param \Exception $exception
+   *   The exception that is going to be logged.
+   * @param string $message
+   *   The message to store in the log.
+   * @param array $variables
+   *   Array of variables to replace in the message on display or
+   *   NULL if message is already translated or not possible to
+   *   translate.
+   * @param int $severity
+   *   The severity of the message, as per RFC 3164.
+   * @param string $link
+   *   A link to associate with the message.
+   *
+   * @see \Drupal\Core\Utility\Error::decodeException()
+   */
+  private function watchdogException(\Exception $exception, $message = NULL, array $variables = [], $severity = RfcLogLevel::ERROR, $link = NULL) {
+    // Use a default value if $message is not set.
+    if (empty($message)) {
+      $message = '%type: @message in %function (line %line of %file).';
+    }
+
+    if ($link) {
+      $variables['link'] = $link;
+    }
+
+    $variables += Error::decodeException($exception);
+
+    $this->logger->log($severity, $message, $variables);
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
@@ -7,8 +7,11 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\media_mpx\DataObjectFactoryCreator;
+use Drupal\media_mpx\MpxLogger;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\ByFields;
 use Lullabot\Mpx\DataService\Sort;
@@ -45,6 +48,20 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
   private $dataObjectFactoryCreator;
 
   /**
+   * The logger for mpx errors.
+   *
+   * @var \Drupal\media_mpx\MpxLogger
+   */
+  private $mpxLogger;
+
+  /**
+   * The system messenger for error reporting.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  private $messenger;
+
+  /**
    * Constructs a PlayerFormatter object.
    *
    * @param string $plugin_id
@@ -65,11 +82,17 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
    *   The entity type manager.
    * @param \Drupal\media_mpx\DataObjectFactoryCreator $data_object_factory_creator
    *   The creator of mpx data factories.
+   * @param \Drupal\media_mpx\MpxLogger $mpx_logger
+   *   The logger for mpx errors.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The system messenger for error reporting.
    */
-  public function __construct(string $plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, string $label, string $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, DataObjectFactoryCreator $data_object_factory_creator) {
+  public function __construct(string $plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, string $label, string $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, DataObjectFactoryCreator $data_object_factory_creator, MpxLogger $mpx_logger, MessengerInterface $messenger) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->entityTypeManager = $entity_type_manager;
     $this->dataObjectFactoryCreator = $data_object_factory_creator;
+    $this->mpxLogger = $mpx_logger;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -85,7 +108,9 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
       $configuration['view_mode'],
       $configuration['third_party_settings'],
       $container->get('entity_type.manager'),
-      $container->get('media_mpx.data_object_factory_creator')
+      $container->get('media_mpx.data_object_factory_creator'),
+      $container->get('media_mpx.exception_logger'),
+      $container->get('messenger')
     );
   }
 
@@ -102,11 +127,26 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
 
     // @todo Cache this.
     $factory = $this->dataObjectFactoryCreator->forObjectType($source_plugin->getAccount()->getUserEntity(), 'Player Data Service', 'Player', '1.6');
-    $player = $factory->load(new Uri($this->getSetting('player')))->wait();
+
+    try {
+      $player = $factory->load(new Uri($this->getSetting('player')))->wait();
+    }
+    catch (TransferException $e) {
+      // If we can't load a player, we can't render any elements.
+      $this->mpxLogger->logException($e);
+      return $element;
+    }
 
     foreach ($items as $delta => $item) {
-      /** @var \Lullabot\Mpx\DataService\Media\Media $mpx_media */
-      $mpx_media = $source_plugin->getMpxObject($entity);
+      try {
+        /** @var \Lullabot\Mpx\DataService\Media\Media $mpx_media */
+        $mpx_media = $source_plugin->getMpxObject($entity);
+      }
+      catch (TransferException $e) {
+        // If this media item is missing, continue on to the next element.
+        $this->mpxLogger->logException($e);
+        continue;
+      }
       $url = new Url($source_plugin->getAccount(), $player, $mpx_media);
 
       // @todo What cache contexts or tags do we set?
@@ -130,7 +170,19 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
     static $options = [];
 
     if (empty($options)) {
-      $options = $this->fetchPlayerOptions();
+      try {
+        $options = $this->fetchPlayerOptions();
+      }
+      catch (TransferException $e) {
+        $this->mpxLogger->logException($e);
+        $this->messenger->addError($this->t('An unexpected error occurred. The full error has been logged. %error',
+          [
+            '%error' => $e->getMessage(),
+          ])
+        );
+
+        return [];
+      }
     }
 
     $elements['player'] = [

--- a/src/UserSessionFactory.php
+++ b/src/UserSessionFactory.php
@@ -7,7 +7,6 @@ use Lullabot\Mpx\TokenCachePool;
 use Symfony\Component\Lock\StoreInterface;
 use Lullabot\Mpx\Client;
 use Drupal\media_mpx\Entity\UserInterface;
-use Lullabot\Mpx\Service\IdentityManagement\User;
 
 /**
  * Factory used to create mpx user sessions.
@@ -61,8 +60,7 @@ class UserSessionFactory {
    *   The new user session.
    */
   public function fromUser(UserInterface $user): UserSession {
-    $mpx_user = new User($user->getUsername(), $user->getPassword());
-    return new UserSession($mpx_user, $this->client, $this->store, $this->tokenCachePool);
+    return new UserSession($user, $this->client, $this->store, $this->tokenCachePool);
   }
 
 }


### PR DESCRIPTION
This PR resolves #16 by:

* Checks the username and password when saving the mpx user form.
* Adds error handling catching HTTP errors to the User, Account, and Player Formatter Settings forms.
* Handles errors when rendering players, logging the exception and continuing to the next item in the list.