### PR TITLE
Fix imported media being owned by Anonymous #21

### DIFF
--- a/src/DataObjectImporter.php
+++ b/src/DataObjectImporter.php
@@ -101,11 +101,13 @@ class DataObjectImporter {
     $media_storage = $this->entityTypeManager->getStorage('media');
     $results = $media_storage->loadByProperties([$source_field->getName() => (string) $mpx_object->getId()]);
 
+    // Create a new entity owned by the admin user.
     if (empty($results)) {
       /** @var \Drupal\media\Entity\Media $new_media_entity */
       $new_media_entity = $media_storage->create([
         $this->entityTypeManager->getDefinition('media')
           ->getKey('bundle') => $media_type->id(),
+        'uid' => 1,
       ]);
       $new_media_entity->set($source_field->getName(), $mpx_object->getId());
       $results = [$new_media_entity];


### PR DESCRIPTION
I took a look at a D7 site, and it has the same issue - imported content is owned by user 0. I think user 1 is a much more reasonable default. If needed, we can add a config setting later to set which user ID imported media gets saved as.