### PR TITLE
Fix infinite cache in notifications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/guzzle_cache": "^2.0",
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "^0.6.0",
+    "lullabot/mpx-php": "^0.6.2",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4"
   },

--- a/src/MpxCacheStrategy.php
+++ b/src/MpxCacheStrategy.php
@@ -35,4 +35,72 @@ class MpxCacheStrategy extends GreedyCacheStrategy {
     return parent::getCacheKey($withoutToken, $varyHeaders);
   }
 
+  /**
+   * Return a CacheEntry or null if no cache.
+   *
+   * GreedyCacheStrategy does not call the parent method in
+   * PrivateCacheStrategy, which is where the no-cache request header is
+   * processed. This copy of the method is nearly identical, except it also
+   * removes a URL check (which is required because mpx forces tokens to be
+   * in the URL and not in a header).
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The request being processed.
+   *
+   * @see \Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy::fetch
+   *
+   * @return \Kevinrob\GuzzleCache\CacheEntry|null
+   *   The cache entry, or NULL if one does not exist.
+   */
+  public function fetch(RequestInterface $request) {
+    /** @var int|null $maxAge */
+    $maxAge = NULL;
+
+    if ($request->hasHeader('Cache-Control')) {
+      $reqCacheControl = new KeyValueHttpHeader($request->getHeader('Cache-Control'));
+      if ($reqCacheControl->has('no-cache')) {
+        // Can't return cache.
+        return NULL;
+      }
+
+      $maxAge = $reqCacheControl->get('max-age', NULL);
+    }
+    elseif ($request->hasHeader('Pragma')) {
+      $pragma = new KeyValueHttpHeader($request->getHeader('Pragma'));
+      if ($pragma->has('no-cache')) {
+        // Can't return cache.
+        return NULL;
+      }
+    }
+
+    $cache = $this->storage->fetch($this->getCacheKey($request));
+    if ($cache !== NULL) {
+      $varyHeaders = $cache->getVaryHeaders();
+
+      // Vary headers exist from a previous response, check if we have a cache
+      // that matches those headers.
+      if (!$varyHeaders->isEmpty()) {
+        $cache = $this->storage->fetch($this->getCacheKey($request, $varyHeaders));
+
+        if (!$cache) {
+          return NULL;
+        }
+      }
+
+      // This is where the original method checks the original request URL.
+      if ($maxAge !== NULL) {
+        if ($cache->getAge() > $maxAge) {
+          // Cache entry is too old for the request requirements!
+          return NULL;
+        }
+      }
+
+      if (!$cache->isVaryEquals($request)) {
+        return NULL;
+      }
+    }
+
+    return $cache;
+  }
+
 }

--- a/src/Plugin/QueueWorker/NotificationQueueWorker.php
+++ b/src/Plugin/QueueWorker/NotificationQueueWorker.php
@@ -97,7 +97,7 @@ class NotificationQueueWorker extends QueueWorkerBase implements ContainerFactor
 
       $media_source = $this->importer::loadMediaSource($notification->getMediaType());
       $factory = $this->dataObjectFactoryCreator->fromMediaSource($media_source);
-      $promises[] = $factory->load($mpx_media->getId());
+      $promises[] = $factory->load($mpx_media->getId(), ['headers' => ['Cache-Control' => 'no-cache']]);
       $media_types[] = $notification->getMediaType();
     }
 

--- a/src/Plugin/media/Source/Media.php
+++ b/src/Plugin/media/Source/Media.php
@@ -275,7 +275,7 @@ class Media extends MediaSourceBase implements MediaSourceInterface {
       $value = $this->getCustomFieldsValue($media, $attribute_name);
     }
 
-    if ($value) {
+    if (!is_null($value)) {
       return $value;
     }
 

--- a/tests/src/Kernel/MediaMpxTestBase.php
+++ b/tests/src/Kernel/MediaMpxTestBase.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\media\Entity\MediaType;
+use Drupal\media_mpx\Entity\Account;
+use Drupal\media_mpx\Entity\User;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use Lullabot\Mpx\Client;
+
+/**
+ * Base class for media_mpx kernel tests.
+ */
+abstract class MediaMpxTestBase extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'field',
+    'file',
+    'user',
+    'image',
+    'guzzle_cache',
+    'media',
+    'media_mpx',
+  ];
+
+  /**
+   * The mock HTTP handler.
+   *
+   * @var \GuzzleHttp\Handler\MockHandler
+   */
+  protected $handler;
+
+  /**
+   * The media source being tested.
+   *
+   * @var \Drupal\media_mpx\Plugin\media\Source\Media
+   */
+  protected $source;
+
+  /**
+   * The media type being tested.
+   *
+   * @var \Drupal\media\MediaTypeInterface
+   */
+  protected $mediaType;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->handler = new MockHandler();
+    /** @var \GuzzleHttp\HandlerStack $handler */
+    $handler = $this->container->get('media_mpx.client')->getConfig('handler');
+    $handler->push(function (callable $handler) {
+      return $this->handler;
+    });
+    $handler->remove('test.http_client.middleware');
+    $client = new Client(new GuzzleClient(['handler' => $handler]));
+    $this->container->set('media_mpx.client', $client);
+    $user = User::create([
+      'label' => 'JavaScript test user',
+      'id' => 'mpx_testing_example_com',
+      'username' => 'mpx/testing@example.com',
+      'password' => 'SECRET',
+    ]);
+    $user->save();
+    $account = Account::create([
+      'label' => 'JavaScript test account',
+      'id' => 'mpx_account',
+      'user' => $user->id(),
+      'account' => 'http://example.com/account/1',
+      'public_id' => 'public-id',
+    ]);
+    $account->save();
+
+    $manager = $this->container->get('plugin.manager.media.source');
+    $this->source = $manager->createInstance('media_mpx_media', [
+      'source_field' => 'field_media_media_mpx_media',
+      'account' => $account->id(),
+    ]);
+
+    $this->mediaType = MediaType::create([
+      'id' => 'mpx',
+      'label' => 'mpx media type',
+      'source' => 'media_mpx_media',
+      'queue_thumbnail_downloads' => TRUE,
+      'source_configuration' => [
+        'source_field' => 'field_media_media_mpx_media',
+        'account' => $account->id(),
+      ],
+    ]);
+    $this->mediaType->save();
+    $source_field = $this->mediaType->getSource()->createSourceField($this->mediaType);
+    $source_field->getFieldStorageDefinition()->save();
+    $source_field->save();
+
+  }
+
+}

--- a/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
+++ b/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\Kernel\Plugin\QueueWorker;
+
+use Drupal\media_mpx\Notification;
+use Drupal\media_mpx_test\JsonResponse;
+use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\Notification as MpxNotification;
+
+/**
+ * Tests notification processing.
+ *
+ * @group media_mpx
+ * @coversDefaultClass \Drupal\media_mpx\Plugin\QueueWorker\NotificationQueueWorker
+ */
+class NotificationQueueWorkerTest extends MediaMpxTestBase {
+
+  /**
+   * Test loads from the notification queue are not returned from the cache.
+   *
+   * @covers ::processItem
+   */
+  public function testNotificationQueueUncached() {
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+    $this->installEntitySchema('media');
+
+    $entry = new Media();
+    $id = new Uri('http://data.media.theplatform.com/media/data/Media/2602559');
+    $entry->setId($id);
+
+    $notification = new MpxNotification();
+    $notification->setEntry($entry);
+    $data[] = new Notification($notification, $this->mediaType);
+
+    $this->handler->append(new JsonResponse(200, [], 'signin-success.json'));
+    $this->handler->append(new JsonResponse(200, [], 'media-object.json'));
+    $this->handler->append(new JsonResponse(200, [], 'media-object.json'));
+
+    // Load a media object into the cache.
+    $factory = $this->container->get('media_mpx.data_object_factory_creator')->fromMediaSource($this->source);
+    $factory->load($id)->wait();
+
+    /** @var \Drupal\media_mpx\Plugin\QueueWorker\NotificationQueueWorker $worker */
+    $worker = $this->container->get('plugin.manager.queue_worker')->createInstance('media_mpx_notification');
+    $worker->processItem($data);
+
+    $this->assertEquals(0, $this->handler->count());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/media/Source/MediaTest.php
+++ b/tests/src/Kernel/Plugin/media/Source/MediaTest.php
@@ -4,16 +4,10 @@ namespace Drupal\Tests\media_mpx\Kernel\Plugin\media\Source;
 
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\media\Entity\Media;
-use Drupal\media\Entity\MediaType;
-use Drupal\media_mpx\Entity\Account;
-use Drupal\media_mpx\Entity\User;
 use Drupal\Tests\media_mpx\Kernel\JsonResponse;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Handler\MockHandler;
+use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;
 use GuzzleHttp\Psr7\Response;
-use Lullabot\Mpx\Client;
 use Lullabot\Mpx\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
@@ -24,26 +18,7 @@ use Psr\Log\LoggerInterface;
  * @group media_mpx
  * @coversDefaultClass \Drupal\media_mpx\Plugin\media\Source\Media
  */
-class MediaTest extends KernelTestBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  protected static $modules = [
-    'field',
-    'file',
-    'user',
-    'image',
-    'media',
-    'media_mpx',
-  ];
-
-  /**
-   * The media source being tested.
-   *
-   * @var \Drupal\media_mpx\Plugin\media\Source\Media
-   */
-  private $source;
+class MediaTest extends MediaMpxTestBase {
 
   /**
    * The media entity to fetch metadata from.
@@ -53,54 +28,10 @@ class MediaTest extends KernelTestBase {
   private $media;
 
   /**
-   * The mock HTTP handler.
-   *
-   * @var \GuzzleHttp\Handler\MockHandler
-   */
-  private $handler;
-
-  /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
-
-    $this->handler = new MockHandler();
-    $client = new Client(new GuzzleClient(['handler' => $this->handler]));
-    $this->container->set('media_mpx.client', $client);
-    $user = User::create([
-      'label' => 'JavaScript test user',
-      'id' => 'mpx_testing_example_com',
-      'username' => 'mpx/testing@example.com',
-      'password' => 'SECRET',
-    ]);
-    $user->save();
-    $account = Account::create([
-      'label' => 'JavaScript test account',
-      'id' => 'mpx_account',
-      'user' => $user->id(),
-      'account' => 'http://example.com/account/1',
-      'public_id' => 'public-id',
-    ]);
-    $account->save();
-
-    $manager = $this->container->get('plugin.manager.media.source');
-    $this->source = $manager->createInstance('media_mpx_media', [
-      'source_field' => 'field_media_media_mpx_media',
-      'account' => $account->id(),
-    ]);
-
-    /** @var \Drupal\media\MediaTypeInterface $media_type */
-    $media_type = MediaType::create([
-      'id' => 'mpx',
-      'label' => 'mpx media type',
-      'source' => 'media_mpx_media',
-    ]);
-    $media_type->save();
-    $source_field = $media_type->getSource()->createSourceField($media_type);
-    $source_field->getFieldStorageDefinition()->save();
-    $source_field->save();
-
     $this->media = Media::create([
       'bundle' => 'mpx',
       'title' => 'test',


### PR DESCRIPTION
This fixes the notification worker sending the cached copy of an updated object instead of fetching a fresh one from mpx.

This depends on https://github.com/Lullabot/mpx-php/pull/138.