### PR TITLE
Update PlayerFormatter.php

### DIFF
--- a/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
@@ -60,7 +60,7 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
    *
    * @var \Drupal\Core\Messenger\MessengerInterface
    */
-  private $messenger;
+  protected $messenger;
 
   /**
    * Constructs a PlayerFormatter object.


### PR DESCRIPTION
FormatterBase.php in Drupal 8.6 uses `protected` as the access modifier for the `$messenger` property, while this class uses private. This causes the following PHP error:

```
[Mon Jul 23 12:43:16.434148 2018] [php7:notice] [pid 1896] [client 127.0.0.1:38106] PHP Fatal error:  Access level to Drupal\\media_mpx\\Plugin\\Field\\FieldFormatter\\PlayerFormatter::$messenger must be protected (as in class Drupal\\Core\\Field\\FormatterBase) or weaker in /var/www/somesite/d8/web/modules/contrib/media_mpx/src/Plugin/Field/FieldFormatter/PlayerFormatter.php on line 35, referer: http://somesite.local/admin/structure/types/manage/blog/display-layout/teaser
```

Here is a screenshot:

![image](https://user-images.githubusercontent.com/108130/43073076-9afa2edc-8e78-11e8-92d1-b3cbfa1e48c7.png)
