### PR TITLE
Fix only storing one notification ID for all media bundles #63

### DIFF
--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -75,7 +75,7 @@ class NotificationQueuer extends DrushCommands {
     // First, we find the last notification ID.
     $media_type = $this->loadMediaType($media_type_id);
     $media_source = DataObjectImporter::loadMediaSource($media_type);
-    $notification_id = $this->listener->getNotificationId($media_source);
+    $notification_id = $this->listener->getNotificationId($media_type_id);
 
     // Next, we fetch notifications, removing duplicates (such as multiple saves
     // of an mpx object in a row).
@@ -87,7 +87,7 @@ class NotificationQueuer extends DrushCommands {
     $this->queueNotifications($media_type, $notifications);
 
     // Let the next listen call start from where we left off.
-    $this->listener->setNotificationId($media_source, end($notifications));
+    $this->listener->setNotificationId($media_type_id, end($notifications));
 
     $this->io()->progressFinish();
   }

--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -108,14 +108,14 @@ class NotificationListener {
   /**
    * Return the current notification ID, or -1 if one is not set.
    *
-   * @param \Drupal\media\MediaSourceInterface $media_source
-   *   The media source the notification ID is for.
+   * @param string $media_type_id
+   *   The media type ID to import for.
    *
    * @return int
    *   The notification ID.
    */
-  public function getNotificationId(MediaSourceInterface $media_source): int {
-    $notification_key = $this->getNotificationKey($media_source);
+  public function getNotificationId(string $media_type_id): int {
+    $notification_key = $this->getNotificationKey($media_type_id);
     if (!$notification_id = $this->state->get($notification_key)) {
       // @todo Should we throw a warning?
       $notification_id = -1;
@@ -127,13 +127,13 @@ class NotificationListener {
   /**
    * Set the last processed notification id.
    *
-   * @param \Drupal\media\MediaSourceInterface $media_source
-   *   The media source the notification ID is for.
+   * @param string $media_type_id
+   *   The media type ID to import for.
    * @param \Lullabot\Mpx\DataService\Notification $notification
    *   The last notification that has been processed.
    */
-  public function setNotificationId(MediaSourceInterface $media_source, Notification $notification) {
-    $notification_key = $this->getNotificationKey($media_source);
+  public function setNotificationId(string $media_type_id, Notification $notification) {
+    $notification_key = $this->getNotificationKey($media_type_id);
     // @todo should this really be state?
     $this->state->set($notification_key, $notification->getId());
   }
@@ -141,14 +141,14 @@ class NotificationListener {
   /**
    * Return the notification key in the state system.
    *
-   * @param \Drupal\media\MediaSourceInterface $media_source
-   *   The media source to generate the key for.
+   * @param string $media_type_id
+   *   The media type ID to import for.
    *
    * @return string
    *   The notification key.
    */
-  private function getNotificationKey(MediaSourceInterface $media_source): string {
-    return $media_source->getPluginId() . '_notification_id';
+  private function getNotificationKey(string $media_type_id): string {
+    return $media_type_id . '_notification_id';
   }
 
 }

--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -3,7 +3,6 @@
 namespace Drupal\media_mpx;
 
 use Drupal\Core\State\StateInterface;
-use Drupal\media\MediaSourceInterface;
 use Drupal\media_mpx\Plugin\media\Source\MpxMediaSourceInterface;
 use GuzzleHttp\Exception\ConnectException;
 use Lullabot\Mpx\DataService\DataServiceManager;


### PR DESCRIPTION
notification id's now have the bundle id's embedded in them.

Solution:
Changed the function parameters to take in the media type id instead of the media source and use it to generate the notification id.

Fixes:
https://github.com/Lullabot/media_mpx/issues/63