### PR TITLE
Retry thumbnails when they fail to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ used to download thumbnails in parallel. Until thumbnails are downloaded, a
 placeholder will be used in admin listing (and on your site, if videos are
 published automatically).
 
+### Handling thumbnail errors
+
+If an error occurs while downloading a thumbnail, Drupal will use the default
+thumbnail for a video. It will not try again later to download the correct
+thumbnail. To work around this, we replace Drupal's thumbnail downloader with
+our own. If the patch from
+[Allow a queue item to be postponed](https://www.drupal.org/project/drupal/issues/1832818#comment-12826680)
+is applied, individual items will be sent to the end of the queue to be tried
+later. Otherwise, queue processing will be suspended until the next cron or
+queue run.
+
 ## Caching of mpx responses
 
 Unfortunately, mpx returns `Cache-control: no-cache` headers in every request.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ is applied, individual items will be sent to the end of the queue to be tried
 later. Otherwise, queue processing will be suspended until the next cron or
 queue run.
 
+Note that there is not a corresponding Drush patch yet for it's `queue:run`
+command. If media thumbnails are processed with that command, do not use the
+above patch, or consider contributing a similar patch to Drush itself.
+
 ## Caching of mpx responses
 
 Unfortunately, mpx returns `Cache-control: no-cache` headers in every request.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Media mpx for Drupal 8
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Requirements](#requirements)
+- [About the mpx name](#about-the-mpx-name)
+- [Metadata mapping support](#metadata-mapping-support)
+- [Video ingestion](#video-ingestion)
+- [Thumbnail integration](#thumbnail-integration)
+  - [Handling thumbnail errors](#handling-thumbnail-errors)
+- [Caching of mpx responses](#caching-of-mpx-responses)
+- [Limiting results during an mpx import](#limiting-results-during-an-mpx-import)
+  - [1. Altering import mpx queries](#1-altering-import-mpx-queries)
+  - [2. Altering ingested mpx objects](#2-altering-ingested-mpx-objects)
+- [Custom field support](#custom-field-support)
+- [Migrating from Media: thePlatform mpx](#migrating-from-media-theplatform-mpx)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 [![CircleCI](https://circleci.com/gh/Lullabot/media_mpx/tree/8.x-1.x.svg?style=svg)](https://circleci.com/gh/Lullabot/media_mpx/tree/8.x-1.x) [![Maintainability](https://api.codeclimate.com/v1/badges/69160a3010c6788be915/maintainability)](https://codeclimate.com/github/Lullabot/media_mpx/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/69160a3010c6788be915/test_coverage)](https://codeclimate.com/github/Lullabot/media_mpx/test_coverage)
 
 This module integrates [mpx for PHP](https://github.com/Lullabot/mpx-php) with

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If an error occurs while downloading a thumbnail, Drupal will use the default
 thumbnail for a video. It will not try again later to download the correct
 thumbnail. To work around this, we replace Drupal's thumbnail downloader with
 our own. If the patch from
-[Allow a queue item to be postponed](https://www.drupal.org/project/drupal/issues/1832818#comment-12826680)
+[Allow a queue item to be postponed](https://www.drupal.org/project/drupal/issues/1832818#comment-12827934)
 is applied, individual items will be sent to the end of the queue to be tried
 later. Otherwise, queue processing will be suspended until the next cron or
 queue run.

--- a/media_mpx.module
+++ b/media_mpx.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\media_mpx\Plugin\QueueWorker\ThumbnailDownloader;
 
 /**
  * Implements hook_help().
@@ -39,6 +40,15 @@ function media_mpx_theme() {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_queue_info_alter().
+ */
+function media_mpx_queue_info_alter(&$queues) {
+  // Alter the queue so we can support recreating jobs if the thumbnail fails
+  // to download.
+  $queues['media_entity_thumbnail']['class'] = ThumbnailDownloader::class;
 }
 
 /**

--- a/src/Plugin/QueueWorker/ThumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/ThumbnailDownloader.php
@@ -40,7 +40,7 @@ class ThumbnailDownloader extends CoreThumbnailDownloader {
       // If core has been patched to support recreating a single queue item,
       // use that.
       // @see https://www.drupal.org/project/drupal/issues/1832818
-      if (!class_exists('\Drupal\Core\Queue\PostponeItemException')) {
+      if (class_exists('\Drupal\Core\Queue\PostponeItemException')) {
         throw new PostponeItemException($message, $e->getCode(), $e);
       }
 

--- a/src/Plugin/QueueWorker/ThumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/ThumbnailDownloader.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\media_mpx\Plugin\QueueWorker;
 
-use Drupal\Core\Queue\RecreateException;
+use Drupal\Core\Queue\PostponeItemException;
 use Drupal\Core\Queue\SuspendQueueException;
 use Drupal\media\Entity\Media;
 use Drupal\media\Plugin\QueueWorker\ThumbnailDownloader as CoreThumbnailDownloader;
@@ -40,8 +40,8 @@ class ThumbnailDownloader extends CoreThumbnailDownloader {
       // If core has been patched to support recreating a single queue item,
       // use that.
       // @see https://www.drupal.org/project/drupal/issues/1832818
-      if (!class_exists('\Drupal\Core\Queue\RecreateException')) {
-        throw new RecreateException($message, $e->getCode(), $e);
+      if (!class_exists('\Drupal\Core\Queue\PostponeItemException')) {
+        throw new PostponeItemException($message, $e->getCode(), $e);
       }
 
       // Otherwise, block the whole queue.

--- a/src/Plugin/QueueWorker/ThumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/ThumbnailDownloader.php
@@ -32,7 +32,7 @@ class ThumbnailDownloader extends CoreThumbnailDownloader {
       $media->updateQueuedThumbnail();
     }
     catch (MpxExceptionInterface $e) {
-      $message = sprintf('There was an error downloading the media entity %entity_id thumbnail from %mpx_id. The thumbnail will be retried later.', [
+      $message = sprintf('There was an error downloading the media entity %thumbnail from %. The thumbnail will be retried later.', [
         $media->id(),
         $media->getSource()->getSourceFieldValue($media),
       ]);

--- a/src/Plugin/QueueWorker/ThumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/ThumbnailDownloader.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\media_mpx\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\RecreateException;
+use Drupal\Core\Queue\SuspendQueueException;
+use Drupal\media\Entity\Media;
+use Drupal\media\Plugin\QueueWorker\ThumbnailDownloader as CoreThumbnailDownloader;
+use Drupal\media_mpx\Plugin\media\Source\MpxMediaSourceInterface;
+use Lullabot\Mpx\Exception\MpxExceptionInterface;
+
+/**
+ * Process a queue of media items to fetch their thumbnails.
+ */
+class ThumbnailDownloader extends CoreThumbnailDownloader {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    // Drupal doesn't allow for individual media sources to define their
+    // thumbnail downloader. Instead, if we are processing any other media item
+    // we defer to core's implementation.
+    if (!$this->isMpxMediaItem($data)) {
+      parent::processItem($data);
+      return;
+    }
+
+    $media = $this->getMedia($data);
+    $media->save();
+    try {
+      $media->updateQueuedThumbnail();
+    }
+    catch (MpxExceptionInterface $e) {
+      $message = sprintf('There was an error downloading the media entity %entity_id thumbnail from %mpx_id. The thumbnail will be retried later.', [
+        $media->id(),
+        $media->getSource()->getSourceFieldValue($media),
+      ]);
+
+      // If core has been patched to support recreating a single queue item,
+      // use that.
+      // @see https://www.drupal.org/project/drupal/issues/1832818
+      if (!class_exists('\Drupal\Core\Queue\RecreateException')) {
+        throw new RecreateException($message, $e->getCode(), $e);
+      }
+
+      // Otherwise, block the whole queue.
+      throw new SuspendQueueException($message, $e->getCode(), $e);
+    }
+
+    $media->save();
+  }
+
+  /**
+   * Determine if the queue data is for an mpx media item.
+   *
+   * @param array $data
+   *   The queue data.
+   *
+   * @return bool
+   *   TRUE if data references an mpx media entity, FALSE otherwise.
+   */
+  private function isMpxMediaItem(array $data): bool {
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = $this->getMedia($data);
+    return $media && $media->getSource() instanceof MpxMediaSourceInterface;
+  }
+
+  /**
+   * Get the media entity referenced by the queue data.
+   *
+   * @param array $data
+   *   The queue data.
+   *
+   * @return \Drupal\media\Entity\Media|null
+   *   The media entity, or null if one could not be loaded.
+   */
+  private function getMedia(array $data): ?Media {
+    /** @var \Drupal\media\Entity\Media $media */
+    $media = $this->entityTypeManager->getStorage('media')->load($data['id']);
+    return $media;
+  }
+
+}

--- a/src/Plugin/QueueWorker/ThumbnailDownloader.php
+++ b/src/Plugin/QueueWorker/ThumbnailDownloader.php
@@ -32,10 +32,7 @@ class ThumbnailDownloader extends CoreThumbnailDownloader {
       $media->updateQueuedThumbnail();
     }
     catch (MpxExceptionInterface $e) {
-      $message = sprintf('There was an error downloading the media entity %thumbnail from %. The thumbnail will be retried later.', [
-        $media->id(),
-        $media->getSource()->getSourceFieldValue($media),
-      ]);
+      $message = sprintf('There was an error downloading the media entity %c thumbnail from %s. The thumbnail will be retried later.', $media->id(), $media->getSource()->getSourceFieldValue($media));
 
       // If core has been patched to support recreating a single queue item,
       // use that.


### PR DESCRIPTION
There's an upstream core issue at https://www.drupal.org/project/drupal/issues/1832818#comment-12826680. I'd like to get feedback there before finalizing this.

Testing:

- [ ] Import a video from mpx, ensuring the bundle is set to queue thumbnail downloads.
- [ ] Make sure you don't run the queue, and then break your mpx calls by changing the mpx password to something invalid.
- [ ] Run cron. An error will be logged and the queue item should be recreated once in the media_entity_thumbnail queue.

TODO:

- [x] Document that `drush queue-run` isn't affected by this patch.
- [x] File an upstream issue to refactor out core's processQueues method so it can be used by drush?
  * Done: https://www.drupal.org/project/drupal/issues/3008997