### PR TITLE
If the notification id is old re-run the query with a notification id of -1

### DIFF
--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -105,7 +105,7 @@ class NotificationListener {
           'The last notification ID %id for %account is older than 7 days and is too old to fetch notifications. The last notification ID has been reset to re-start ingestion of all videos.',
           [
             '%id' => $notification_id,
-            '%account' => $account->getPid(),
+            '%account' => $media_source->getAccount()->label(),
           ]);
 
         return $this->listen($media_source, -1);

--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Exception\ConnectException;
 use Lullabot\Mpx\DataService\DataServiceManager;
 use Lullabot\Mpx\DataService\Notification;
 use Lullabot\Mpx\DataService\NotificationListener as MpxNotificationListener;
-use Lullabot\Mpx\Exception\ApiException;
 use Lullabot\Mpx\Exception\ClientException;
 use Psr\Log\LoggerInterface;
 

--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -91,7 +91,7 @@ class NotificationListener {
     try {
       return $promise->wait();
     }
-    catch (ConnectException $e) {
+    catch (ConnectException | ClientException $e) {
       // This may be a timeout if no notifications are available. However, there
       // is no good method from the exception to determine if a timeout
       // occurred.
@@ -100,10 +100,6 @@ class NotificationListener {
         return [];
       }
 
-      // Some other connection exception occurred, so throw that up.
-      throw $e;
-    }
-    catch (ClientException $e) {
       if ($e->getCode() == 404) {
         $this->logger->warning(
           'The last notification ID %id for %account is older than 7 days and is too old to fetch notifications. The last notification ID has been reset to re-start ingestion of all videos.',
@@ -115,6 +111,7 @@ class NotificationListener {
         return $this->listen($media_source, -1);
       }
 
+      // Some other connection exception occurred, so throw that up.
       throw $e;
     }
   }


### PR DESCRIPTION
Resolves: https://github.com/Lullabot/media_mpx/issues/30