### PR TITLE
Use yield to handle parallel requests

### DIFF
--- a/src/Plugin/QueueWorker/NotificationQueueWorker.php
+++ b/src/Plugin/QueueWorker/NotificationQueueWorker.php
@@ -4,7 +4,6 @@ namespace Drupal\media_mpx\Plugin\QueueWorker;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\media\MediaTypeInterface;
 use Drupal\media_mpx\DataObjectFactoryCreator;
 use Drupal\media_mpx\DataObjectImporter;
 use function GuzzleHttp\Promise\each_limit;

--- a/src/Plugin/QueueWorker/NotificationQueueWorker.php
+++ b/src/Plugin/QueueWorker/NotificationQueueWorker.php
@@ -109,8 +109,12 @@ class NotificationQueueWorker extends QueueWorkerBase implements ContainerFactor
    *
    * @see https://github.com/guzzle/guzzle/pull/2001
    *
+   * @codingStandardsIgnoreStart
+   * https://www.drupal.org/project/coder/issues/2906931
+   *
    * @return \Generator
    *   A generator that yields promises to a loaded mpx media object.
+   * @codingStandardsIgnoreEnd
    */
   private function yieldLoads(array $notifications): \Generator {
     foreach ($notifications as $notification) {


### PR DESCRIPTION
https://github.com/guzzle/guzzle/pull/2001 only works if we yield requests. If we put them into an array, they are all delayed until they are waited on, negating the performance benefits of using `each_limit`.

With that patch applied, and without this PR, a test import took ~60 seconds, and with this PR it was down to ~30 seconds.