### PR TITLE
Log the notification time

### DIFF
--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -143,8 +143,9 @@ class NotificationQueuer extends DrushCommands {
     foreach ($chunks as $chunk) {
       $items = [];
       foreach ($chunk as $notification) {
-        $this->logger()->debug(dt('Queuing @method notification for object @id', [
-          '@method' => $notification->getMethod(),
+        $this->logger()->debug(dt('Queuing @method notification at @time for object @id', [
+          '@method' => strtoupper($notification->getMethod()),
+          '@time' => $notification->getEntry()->getUpdated()->format('c'),
           '@id' => $notification->getEntry()->getId(),
         ]));
 


### PR DESCRIPTION
This can't be merged yet until we have a new tag of mpx-php.

This is helpful mostly on locals, where your notifications may be delayed and you want to know how close you are to "real time".