### PR TITLE
Map created and changed properties at the migration

### DIFF
--- a/migrations/d7_media_theplatform_mpx.yml
+++ b/migrations/d7_media_theplatform_mpx.yml
@@ -11,6 +11,8 @@ process:
   bundle: type
   name: filename
   status: published
+  created: mpx_created
+  changed: updated
   field_mpx_url:
     plugin: get
     source: mpx_url

--- a/src/Plugin/migrate/source/MediaMpxEntityItem.php
+++ b/src/Plugin/migrate/source/MediaMpxEntityItem.php
@@ -31,6 +31,7 @@ class MediaMpxEntityItem extends FieldableEntity {
         'guid',
         'description',
         'released_file_pids',
+        'updated',
         'default_released_file_pid',
         'categories',
         'author',
@@ -50,6 +51,7 @@ class MediaMpxEntityItem extends FieldableEntity {
         'countries',
       ])
       ->orderBy('f.timestamp');
+    $query->addField('m', 'created', 'mpx_created');
     $query->innerJoin('mpx_video', 'm', 'f.fid = m.fid');
 
     // Filter by type, if configured.


### PR DESCRIPTION
I found that the following properties were getting the current timestamp values instead of the ones from the source database:

![image](https://user-images.githubusercontent.com/108130/47956672-5813ea00-dfa8-11e8-8867-5b597df173fe.png)
