### PR TITLE
Support description, duration, and embedUrl values

### DIFF
--- a/media_mpx.module
+++ b/media_mpx.module
@@ -42,6 +42,8 @@ function media_mpx_theme() {
         'attributes' => [],
         'meta' => [],
         'content' => [],
+        'entity' => NULL,
+        'mpx_media' => NULL,
       ],
     ],
     'media_mpx_iframe' => [

--- a/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
@@ -362,10 +362,14 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
    * Build the URL for a player iframe.
    *
    * @param \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin
+   *   The source plugin associated with the media.
    * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
+   *   The mpx media object.
    * @param \Lullabot\Mpx\DataService\Player\Player $player
+   *   The player to build the URL for.
    *
-   * @return Url
+   * @return \Lullabot\Mpx\Service\Player\Url
+   *   The player URL.
    */
   private function buildUrl(Media $source_plugin, MpxMedia $mpx_media, Player $player): Url {
     $url = new Url($source_plugin->getAccount(), $player, $mpx_media);

--- a/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/PlayerFormatter.php
@@ -275,8 +275,6 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
       return NULL;
     }
 
-    $thumbnail_url = file_create_url($source_plugin->getMetadata($entity, 'thumbnail_uri'));
-
     $element = [
       '#type' => 'media_mpx_iframe_wrapper',
       '#attributes' => [
@@ -284,13 +282,7 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
           'mpx-iframe-wrapper',
         ],
       ],
-      '#meta' => [
-        'name' => $entity->label(),
-        'thumbnailUrl' => $thumbnail_url,
-        'description' => $mpx_media->getDescription(),
-        'uploadDate' => $mpx_media->getAvailableDate()->format(DATE_ISO8601),
-        'embedUrl' => (string) $this->buildUrl($source_plugin, $mpx_media, $player),
-      ],
+      '#meta' => $this->buildMeta($entity, $mpx_media, $player),
       '#content' => $this->buildPlayer($source_plugin, $player, $mpx_media),
       '#entity' => $entity,
       '#mpx_media' => $mpx_media,
@@ -374,6 +366,31 @@ class PlayerFormatter extends FormatterBase implements ContainerFactoryPluginInt
   private function buildUrl(Media $source_plugin, MpxMedia $mpx_media, Player $player): Url {
     $url = new Url($source_plugin->getAccount(), $player, $mpx_media);
     return $url;
+  }
+
+  /**
+   * Build the metadata keys for schema.org tags.
+   *
+   * @param \Drupal\media\Entity\Media $entity
+   *   The media entity being rendered.
+   * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
+   *   The mpx media object.
+   * @param \Lullabot\Mpx\DataService\Player\Player $player
+   *   The player being rendered.
+   *
+   * @return array
+   *   An array of schema.org data.
+   */
+  private function buildMeta(DrupalMedia $entity, MpxMedia $mpx_media, Player $player): array {
+    /** @var \Drupal\media_mpx\Plugin\media\Source\Media $source_plugin */
+    $source_plugin = $entity->getSource();
+    return [
+      'name' => $entity->label(),
+      'thumbnailUrl' => file_create_url($source_plugin->getMetadata($entity, 'thumbnail_uri')),
+      'description' => $mpx_media->getDescription(),
+      'uploadDate' => $mpx_media->getAvailableDate()->format(DATE_ISO8601),
+      'embedUrl' => (string) $this->buildUrl($source_plugin, $mpx_media, $player),
+    ];
   }
 
 }


### PR DESCRIPTION
I was working on implementing this on a site, and I discovered:

* While the site was mapping descriptions to Drupal fields, the edit forms are set so they aren't editable. In other words, the data is still read-only.
* In thinking through that, I changed my mind on how to handle attributes that could be overridden. Instead of not including them, we should include default reasonable values from mpx (like we do for other values). Sites can override those defaults with Drupal fields if they so choose. To support that, I've added entity and mpx_media variables to the theme hook.