### PR TITLE
Implement a caching mechanism for the API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "highwire/drupal-psr-16": "^1.0",
     "lullabot/mpx-php": "^0.8.2",
     "lullabot/drupal-symfony-lock": "^1.0",
-    "symfony/property-info": "^3.4"
+    "symfony/property-info": "^3.4",
+    "psr/simple-cache": "^1.0"
   },
   "require-dev": {
     "cweagans/composer-patches": "^1.6",

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -66,10 +66,25 @@ services:
     class: Drupal\media_mpx\ClientFactory
     arguments: ['@media_mpx.http_handler_stack', '@http_client_factory', '@cache.media_mpx_http']
 
+  # Defines an array or memory cache that supports a limit on the number of
+  # items.
+  cache.backend.media_mpx.array_cache_pool:
+    class: Drupal\media_mpx\ArrayCachePoolFactory
+    arguments: ['@datetime.time', '@cache_tags.invalidator.checksum', 100]
+
+  # Use the above array cache on top of the normal HTTP request cache. We use
+  # the ChainedFastBackend cache so any invalidations on the consistent cache
+  # are shared with all threads.
+  cache.backend.media_mpx.chainedfast_http:
+    class: Drupal\Core\Cache\ChainedFastBackendFactory
+    arguments: ['@settings', null, cache.backend.media_mpx.array_cache_pool]
+    calls:
+      - [setContainer, ['@service_container']]
+
   cache.media_mpx_http:
     class: Drupal\Core\Cache\CacheBackendInterface
     tags:
-      - { name: cache.bin }
+      - { name: cache.bin , default_backend: cache.backend.media_mpx.chainedfast_http}
     factory: cache_factory:get
     arguments: [media_mpx_http]
 
@@ -79,22 +94,47 @@ services:
     public: false
     arguments: ['@lock']
 
+  # Factory for the \Drupal\Core\Cache\BackendChain class. Core does not ship
+  # with a factory for this class as it no longer uses this class itself.
+  # However, for the metadata cache (which holds the information Symfony uses
+  # to deserialize responses) we do not need a consistent cache since only a
+  # code change can invalidate the cache. Note that using ChainedFastBackend
+  # for the metadata cache incurs a significant performance hit, as every
+  # single call to invalidate cache tags invalidates the whole fast cache.
+  cache.backend.media_mpx.array_backend_chain:
+    class: Drupal\media_mpx\ArrayBackendChainFactory
+    arguments: ['@settings']
+    calls:
+      - [setContainer, ['@service_container']]
+
   # The mpx-php library implements PSR-6, but there is only a PSR-16 cache
   # adapter for Drupal. We use Symfony to bridge PSR-16 to PSR-6.
-  media_mpx.simple_cache_backend:
+  cache.media_mpx_metadata:
+    class: Drupal\Core\Cache\CacheBackendInterface
+    tags:
+      - { name: cache.bin, default_backend: cache.backend.media_mpx.array_backend_chain }
+    factory: cache_factory:get
+    arguments: [media_mpx_metadata]
+
+  media_mpx.simple_cache_backend_default:
     class: HighWire\DrupalPSR16\Cache
     public: false
     arguments: ['@cache.default']
 
+  media_mpx.simple_cache_backend_metadata:
+    class: HighWire\DrupalPSR16\Cache
+    public: false
+    arguments: ['@cache.media_mpx_metadata']
+
   media_mpx.token_cache_pool_adapter:
     class: Symfony\Component\Cache\Adapter\SimpleCacheAdapter
     public: false
-    arguments: ['@media_mpx.simple_cache_backend', 'media_mpx_token']
+    arguments: ['@media_mpx.simple_cache_backend_default', 'media_mpx_token']
 
   media_mpx.metadata_cache_pool_adapter:
     class: Symfony\Component\Cache\Adapter\SimpleCacheAdapter
     public: false
-    arguments: ['@media_mpx.simple_cache_backend', 'media_mpx_metadata']
+    arguments: ['@media_mpx.simple_cache_backend_metadata', 'media_mpx_metadata']
 
   media_mpx.token_cache_pool:
     class: Lullabot\Mpx\TokenCachePool

--- a/media_mpx.services.yml
+++ b/media_mpx.services.yml
@@ -77,7 +77,7 @@ services:
   # are shared with all threads.
   cache.backend.media_mpx.chainedfast_http:
     class: Drupal\Core\Cache\ChainedFastBackendFactory
-    arguments: ['@settings', null, cache.backend.media_mpx.array_cache_pool]
+    arguments: ['@settings', null, 'cache.backend.media_mpx.array_cache_pool']
     calls:
       - [setContainer, ['@service_container']]
 

--- a/src/ArrayBackendChainFactory.php
+++ b/src/ArrayBackendChainFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Drupal\Core\Cache\BackendChain;
+use Drupal\Core\Cache\CacheFactoryInterface;
+use Drupal\Core\Site\Settings;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Factory that returns an inconsistent array-backed cache.
+ */
+class ArrayBackendChainFactory implements CacheFactoryInterface {
+
+  use ContainerAwareTrait;
+
+  /**
+   * The name of the consistent backend cache, typically the database.
+   *
+   * @var string
+   */
+  protected $consistentServiceName;
+
+  /**
+   * ArrayBackendChainFactory constructor.
+   *
+   * @param \Drupal\Core\Site\Settings|null $settings
+   *   (optional) The system settings containing cache configuration.
+   * @param string|null $consistent_service_name
+   *   The name of the consistent backend cache service.
+   */
+  public function __construct(Settings $settings = NULL, string $consistent_service_name = NULL) {
+    // Default the consistent backend to the site's default backend.
+    if (!isset($consistent_service_name)) {
+      $cache_settings = isset($settings) ? $settings->get('cache') : [];
+      $consistent_service_name = isset($cache_settings['default']) ? $cache_settings['default'] : 'cache.backend.database';
+    }
+
+    $this->consistentServiceName = $consistent_service_name;
+  }
+
+  /**
+   * Gets a cache backend class for a given cache bin.
+   *
+   * @param string $bin
+   *   The cache bin for which a cache backend object should be returned.
+   *
+   * @return \Drupal\Core\Cache\CacheBackendInterface
+   *   The cache backend object associated with the specified bin.
+   */
+  public function get($bin) {
+    $chain = new BackendChain($bin);
+    $chain->appendBackend($this->container->get('cache.backend.memory')->get($bin));
+    $chain->appendBackend($this->container->get($this->consistentServiceName)->get($bin));
+
+    return $chain;
+  }
+
+}

--- a/src/ArrayCachePoolFactory.php
+++ b/src/ArrayCachePoolFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheFactoryInterface;
+use Drupal\Core\Cache\CacheTagsChecksumInterface;
+
+/**
+ * Factory that returns an adapted ArrayCachePool.
+ */
+class ArrayCachePoolFactory implements CacheFactoryInterface {
+
+  /**
+   * The system time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The tag checksum provider.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+   */
+  protected $checksumProvider;
+
+  /**
+   * The maximum number of items to cache at once.
+   *
+   * @var int
+   */
+  protected $limit;
+
+  /**
+   * An array of instantiated cache pools.
+   *
+   * @var \Drupal\media_mpx\SimpleCacheBackendAdapter
+   */
+  protected $bins = [];
+
+  /**
+   * ArrayCachePoolFactory constructor.
+   *
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The system time service.
+   * @param \Drupal\Core\Cache\CacheTagsChecksumInterface $checksumProvider
+   *   The tag checksum provider.
+   * @param int|null $limit
+   *   (optional) The maximum number of items to cache at once.
+   */
+  public function __construct(TimeInterface $time, CacheTagsChecksumInterface $checksumProvider, int $limit = NULL) {
+    $this->time = $time;
+    $this->checksumProvider = $checksumProvider;
+    $this->limit = $limit;
+  }
+
+  /**
+   * Gets a cache backend class for a given cache bin.
+   *
+   * @param string $bin
+   *   The cache bin for which a cache backend object should be returned.
+   *
+   * @return \Drupal\Core\Cache\CacheBackendInterface
+   *   The cache backend object associated with the specified bin.
+   */
+  public function get($bin) {
+    if (!isset($this->bins[$bin])) {
+      $cache = new ArrayCachePool($this->limit);
+      $adapted = new SimpleCacheBackendAdapter($cache, $this->time, $this->checksumProvider);
+      $this->bins[$bin] = $adapted;
+    }
+
+    return $this->bins[$bin];
+  }
+
+}

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -201,11 +201,18 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
    *   The mpx object.
    */
   public function getMpxObject(MediaInterface $media): ObjectInterface {
+    static $cache = [];
+
+    if (isset($cache[$media->id()])) {
+      return $cache[$media->id()];
+    }
+
     $id = $media->get($this->configuration['source_field'])->getString();
     $factory = $this->dataObjectFactoryCreator->fromMediaSource($this);
 
-    return $factory->load(new Uri($id))->wait();
+    $cache[$media->id()] = $factory->load(new Uri($id))->wait();
 
+    return $cache[$media->id()];
   }
 
   /**

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -207,6 +207,11 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
       return $cache[$media->id()];
     }
 
+    // To avoid memory issues, reset the cache once it contains 100 elements.
+    if (count($cache) == 100) {
+      $cache = [];
+    }
+
     $id = $media->get($this->configuration['source_field'])->getString();
     $factory = $this->dataObjectFactoryCreator->fromMediaSource($this);
 

--- a/src/Plugin/media/Source/MediaSourceBase.php
+++ b/src/Plugin/media/Source/MediaSourceBase.php
@@ -201,23 +201,10 @@ abstract class MediaSourceBase extends DrupalMediaSourceBase implements MpxMedia
    *   The mpx object.
    */
   public function getMpxObject(MediaInterface $media): ObjectInterface {
-    static $cache = [];
-
-    if (isset($cache[$media->id()])) {
-      return $cache[$media->id()];
-    }
-
-    // To avoid memory issues, reset the cache once it contains 100 elements.
-    if (count($cache) == 100) {
-      $cache = [];
-    }
-
     $id = $media->get($this->configuration['source_field'])->getString();
     $factory = $this->dataObjectFactoryCreator->fromMediaSource($this);
 
-    $cache[$media->id()] = $factory->load(new Uri($id))->wait();
-
-    return $cache[$media->id()];
+    return $factory->load(new Uri($id))->wait();
   }
 
   /**

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -78,19 +78,7 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
 
     // $items can be an iterable and not just an array, so we can't use array_*
     // functions here.
-    $ret = [];
-    foreach ($items as $item) {
-      // $item is null if it could not be found, but it's an interable so we
-      // can't use array_filter().
-      if (!$item) {
-        continue;
-      }
-
-      $item = $this->prepareItem($item, $allow_invalid);
-      if ($item) {
-        $ret[$item->cid] = $item;
-      }
-    }
+    $ret = $this->prepareGetMultiple($items, $allow_invalid);
 
     $cids = array_diff($cids, array_keys($ret));
 
@@ -322,6 +310,34 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
       $keys[] = $this->keyFromCid($cid);
     }
     return $keys;
+  }
+
+  /**
+   * Generate the array of returns suitable for getMultiple().
+   *
+   * @param iterable $items
+   *   The iterable of cache items, including cache misses.
+   * @param bool $allow_invalid
+   *   Allow invalid items to be returned.
+   *
+   * @return \stdClass[]
+   *   An array of Drupal cache items.
+   */
+  private function prepareGetMultiple(iterable $items, $allow_invalid): array {
+    $ret = [];
+    foreach ($items as $item) {
+      // $item is null if it could not be found, but it's an iterable so we
+      // can't use array_filter().
+      if (!$item) {
+        continue;
+      }
+
+      $item = $this->prepareItem($item, $allow_invalid);
+      if ($item) {
+        $ret[$item->cid] = $item;
+      }
+    }
+    return $ret;
   }
 
 }

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -269,7 +269,7 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
 
     $cache->data = $data;
     return $cache;
-}
+  }
 
   /**
    * Convert an absolute expiry to a relative time from now.

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -205,17 +205,12 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
     }
 
     $cache->tags = $cache->tags ? explode(' ', $cache->tags) : [];
-    $cache->valid = TRUE;
 
     // Check if invalidateTags() has been called with any of the entry's tags.
     if (!$this->cache instanceof TaggableCacheItemPoolInterface) {
-      if (!$this->checksumProvider->isValid($cache->checksum, $cache->tags)) {
-        $cache->valid = FALSE;
+      if (!$this->checksumProvider->isValid($cache->checksum, $cache->tags) && !$allow_invalid) {
+        return FALSE;
       }
-    }
-
-    if (!$allow_invalid && !$cache->valid) {
-      return FALSE;
     }
 
     return $cache;

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -323,12 +323,7 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
     foreach ($items as $item) {
       // $item is null if it could not be found, but it's an iterable so we
       // can't use array_filter().
-      if (!$item) {
-        continue;
-      }
-
-      $item = $this->prepareItem($item, $allow_invalid);
-      if ($item) {
+      if ($item && $item = $this->prepareItem($item, $allow_invalid)) {
         $ret[$item->cid] = $item;
       }
     }

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Drupal\media_mpx;
+
+use Cache\TagInterop\TaggableCacheItemPoolInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Cache\CacheTagsChecksumInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Adapter to use PSR-16 cache backends as a Drupal backend cache.
+ *
+ * While it is not part of a PSR, it is recommended that the adapted cache
+ * implements \Cache\TagInterop\TaggableCacheItemPoolInterface. Otherwise,
+ * each cache read will cause a database query to check to see if any tags have
+ * been invalidated.
+ *
+ * @todo This class should be split out into it's own project.
+ *
+ * @see \Drupal\Core\Cache\ApcuBackend::prepareItem
+ */
+class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInvalidatorInterface {
+
+  /**
+   * The adapted cache.
+   *
+   * @var \Psr\SimpleCache\CacheInterface
+   */
+  protected $cache;
+
+  /**
+   * The service used to get the time.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The checksum provider to implement tags support.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsChecksumInterface
+   */
+  protected $checksumProvider;
+
+  /**
+   * SimpleCacheBackendAdapter constructor.
+   *
+   * @param \Psr\SimpleCache\CacheInterface $cache
+   *   The adapted cache.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The service used to get the time.
+   * @param \Drupal\Core\Cache\CacheTagsChecksumInterface $checksumProvider
+   *   The checksum provider to implement tags support.
+   */
+  public function __construct(CacheInterface $cache, TimeInterface $time, CacheTagsChecksumInterface $checksumProvider) {
+    $this->cache = $cache;
+    $this->time = $time;
+    $this->checksumProvider = $checksumProvider;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($cid, $allow_invalid = FALSE) {
+    $key = $this->keyFromCid($cid);
+    return $this->prepareItem($this->cache->get($key), $allow_invalid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMultiple(&$cids, $allow_invalid = FALSE) {
+    $keys = $this->keysFromCids($cids);
+    $items = $this->cache->getMultiple($keys);
+
+    // $items can be an iterable and not just an array, so we can't use array_*
+    // functions here.
+    $ret = [];
+    foreach ($items as $item) {
+      // $item is null if it could not be found, but it's an interable so we
+      // can't use array_filter().
+      if (!$item) {
+        continue;
+      }
+
+      $item = $this->prepareItem($item, $allow_invalid);
+      if ($item) {
+        $ret[$item->cid] = $item;
+      }
+    }
+
+    $cids = array_diff($cids, array_keys($ret));
+
+    return $ret;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function set($cid, $data, $expire = Cache::PERMANENT, array $tags = []) {
+    $cache = $this->createCacheItem($cid, $data, $expire, $tags);
+
+    $key = $this->keyFromCid($cid);
+    $expire = $this->expireAsRelative($expire);
+    $this->cache->set($key, $cache, $expire);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setMultiple(array $items) {
+    foreach ($items as $cid => $item) {
+      // setMultiple() only supports a single TTL for all items so we have to do
+      // individual sets.
+      $tags = isset($item['tags']) ? $item['tags'] : [];
+      $this->set($cid, $item['data'], $item['expire'], $tags);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($cid) {
+    $key = $this->keyFromCid($cid);
+    $this->cache->delete($key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteMultiple(array $cids) {
+    $keys = $this->keysFromCids($cids);
+    $this->cache->deleteMultiple($keys);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteAll() {
+    $this->cache->clear();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidate($cid) {
+    $this->invalidateMultiple([$cid]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidateMultiple(array $cids) {
+    foreach ($this->getMultiple($cids) as $cache) {
+      $this->set($cache->cid, $cache, $this->time->getRequestTime() - 1);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidateAll() {
+    // Handle invalidateAll() including backends that don't support listing all
+    // keys.
+    // @see \Drupal\memcache\MemcacheBackend::invalidateAll
+    $this->invalidateTags(["simple_cache_adapter"]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function garbageCollection() {
+    // PSR-16 does not have an interface for garbage collection.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeBin() {
+    // PSR-16 does not have an interface to delete a bin, but we can at least
+    // clear the cache.
+    $this->cache->clear();
+  }
+
+  /**
+   * Marks cache items with any of the specified tags as invalid.
+   *
+   * @param string[] $tags
+   *   The list of tags for which to invalidate cache items.
+   */
+  public function invalidateTags(array $tags) {
+    if ($this->cache instanceof TaggableCacheItemPoolInterface) {
+      $this->cache->invalidateTags($tags);
+    }
+  }
+
+  /**
+   * Prepares a cached item.
+   *
+   * Checks that the item is either permanent or did not expire.
+   *
+   * @param \stdClass $cache
+   *   An item loaded from cache_get() or cache_get_multiple().
+   * @param bool $allow_invalid
+   *   If TRUE, a cache item may be returned even if it is expired or has been
+   *   invalidated. See ::get().
+   *
+   * @return mixed
+   *   The cache item or FALSE if the item expired.
+   */
+  private function prepareItem(\stdClass $cache, bool $allow_invalid) {
+    if (!isset($cache->data)) {
+      return FALSE;
+    }
+
+    $cache->tags = $cache->tags ? explode(' ', $cache->tags) : [];
+    $cache->valid = TRUE;
+
+    // Check if invalidateTags() has been called with any of the entry's tags.
+    if (!$this->cache instanceof TaggableCacheItemPoolInterface) {
+      if (!$this->checksumProvider->isValid($cache->checksum, $cache->tags)) {
+        $cache->valid = FALSE;
+      }
+    }
+
+    if (!$allow_invalid && !$cache->valid) {
+      return FALSE;
+    }
+
+    return $cache;
+  }
+
+  /**
+   * Create a Drupal \stdClass cache item.
+   *
+   * @param string $cid
+   *   The Drupal cache ID.
+   * @param mixed $data
+   *   The data to cache.
+   * @param int $expire
+   *   The absolute expiry of the cache item.
+   * @param string[] $tags
+   *   An array of cache tags.
+   *
+   * @return \stdClass
+   *   The cache item.
+   */
+  private function createCacheItem($cid, $data, $expire, array $tags): \stdClass {
+    // Additional tag to support invalidateAll().
+    $tags[] = 'simple_cache_adapter';
+    $tags = array_unique($tags);
+    // Sort the cache tags so that they are stored consistently in the database.
+    sort($tags);
+
+    $cache = new \stdClass();
+    $cache->cid = $cid;
+    $cache->created = round(microtime(TRUE), 3);
+    $cache->expire = $expire;
+    $cache->tags = implode(' ', $tags);
+
+    // By default, the database provider is used by Drupal, so save a query if
+    // the adapted cache supports tags directly.
+    if (!$this->cache instanceof TaggableCacheItemPoolInterface) {
+      $cache->checksum = $this->checksumProvider->getCurrentChecksum($tags);
+    }
+
+    $cache->data = $data;
+    return $cache;
+}
+
+  /**
+   * Convert an absolute expiry to a relative time from now.
+   *
+   * @param int $expire
+   *   The absolute timestamp.
+   *
+   * @return int|null
+   *   A relative time if $expire is a timestamp, or NULL if it is
+   *   Cache::PERMANENT.
+   */
+  private function expireAsRelative(int $expire): ?int {
+    if ($expire == Cache::PERMANENT) {
+      $expire = NULL;
+    }
+    else {
+      $expire = $expire - $this->time->getCurrentTime();
+    }
+
+    return $expire;
+  }
+
+  /**
+   * Hash a cache ID so it is a valid PSR-6 / PSR-16 key.
+   *
+   * @param string $cid
+   *   The Drupal cache ID.
+   *
+   * @see http://www.php-cache.com/en/latest/introduction/#cache-keys
+   *
+   * @return string
+   *   A safe cache ID.
+   */
+  private function keyFromCid(string $cid): string {
+    return sha1($cid);
+  }
+
+  /**
+   * Hash multiple cache IDs.
+   *
+   * @param string[] $cids
+   *   An array of Drupal cache IDs.
+   *
+   * @return array
+   *   An array of safe cache IDS.
+   */
+  private function keysFromCids(array $cids): array {
+    $keys = [];
+    foreach ($cids as $cid) {
+      $keys[] = $this->keyFromCid($cid);
+    }
+    return $keys;
+  }
+
+}


### PR DESCRIPTION
Thumbnail processing, field mapping, xmlsitemap access, and
many others will end up calling getMpxObject() several times
for the same entity.

This change suggests that, during the same request, we could
cache the result of the MPX API, reducing the number of
requests per media entity to 1.