### PR TITLE
Log when a notification fails (such as with a deleted video)

### DIFF
--- a/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
+++ b/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\media_mpx\Kernel\Plugin\QueueWorker;
 
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\media_mpx\Notification;
 use Drupal\media_mpx_test\JsonResponse;
 use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;
@@ -11,6 +12,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\Notification as MpxNotification;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests notification processing.
@@ -52,6 +54,43 @@ class NotificationQueueWorkerTest extends MediaMpxTestBase {
     // Load a media object into the cache.
     $factory = $this->container->get('media_mpx.data_object_factory_creator')->fromMediaSource($this->source);
     $factory->load($id)->wait();
+
+    /** @var \Drupal\media_mpx\Plugin\QueueWorker\NotificationQueueWorker $worker */
+    $worker = $this->container->get('plugin.manager.queue_worker')->createInstance('media_mpx_notification');
+    $worker->processItem($data);
+
+    $this->assertEquals(0, $this->handler->count());
+  }
+
+  /**
+   * Test errors in the queue are logged.
+   *
+   * @covers ::processItem
+   */
+  public function testNotificationQueueErrorsLogged() {
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface $logger */
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('log');
+    $this->container->get('logger.factory')->addLogger($logger);
+
+    $entry = new Media();
+    $id = new Uri('http://data.media.theplatform.com/media/data/Media/2602559');
+    $entry->setId($id);
+
+    $notification = new MpxNotification();
+    $notification->setEntry($entry);
+    $data[] = new Notification($notification, $this->mediaType);
+
+    $this->handler->append(new JsonResponse(200, [], 'signin-success.json'));
+    $error = \GuzzleHttp\json_encode([
+      'responseCode' => 404,
+      'isException' => TRUE,
+      'description' => 'Object not found',
+      'title' => '404 Not Found',
+      'correlationId' => 'the-correlation-id',
+    ]);
+    $this->handler->append(new JsonResponse(200, [], $error));
 
     /** @var \Drupal\media_mpx\Plugin\QueueWorker\NotificationQueueWorker $worker */
     $worker = $this->container->get('plugin.manager.queue_worker')->createInstance('media_mpx_notification');

--- a/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
+++ b/tests/src/Kernel/Plugin/QueueWorker/NotificationQueueWorkerTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\media_mpx\Kernel\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\media_mpx\Notification;
 use Drupal\media_mpx_test\JsonResponse;
 use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;


### PR DESCRIPTION
Without this, failures are silently discarded. I had incorrectly assumed that a `null` rejection callback would cause exceptions to bubble.