### PR TITLE
Default to processing all notifications at once

### DIFF
--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -260,13 +260,12 @@ class NotificationQueuer extends DrushCommands {
    */
   private function doListen($media_type_id, bool $once = FALSE): void {
     $more_to_consume = TRUE;
-    $notifications_to_queue = [];
-
-    $media_type = $this->loadMediaType($media_type_id);
-    $media_source = DataObjectImporter::loadMediaSource($media_type);
 
     while ($more_to_consume) {
       // First, we find the last notification ID.
+      $media_type = $this->loadMediaType($media_type_id);
+      $media_source = DataObjectImporter::loadMediaSource($media_type);
+
       $notification_id = $this->listener->getNotificationId($media_type_id);
 
       // Next, we fetch notifications, removing duplicates (such as multiple
@@ -286,33 +285,29 @@ class NotificationQueuer extends DrushCommands {
       // Check to see if there were no notifications and we got a sync response.
       // @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications#tp-toc10
       if ($initial_count === 1 && $last_notification->isSyncResponse()) {
-        $this->logger()->info(dt('All notifications have been retrieved.'));
+        $this->logger()->info(dt('All notifications have been processed.'));
         $more_to_consume = FALSE;
       }
       else {
-        // Take the notifications and store them in the queue for processing
-        // later.
-        $notifications_to_queue = array_merge($notifications_to_queue, $notifications);
-        $notifications_to_queue = $this->filterDuplicateNotifications($notifications_to_queue);
-        $notifications_to_queue = $this->filterByDate($notifications_to_queue, $media_type_id);
-        $this->logger()->debug(dt('@count notifications are waiting to be queued.', ['@count' => count($notifications_to_queue)]));
+        $notifications = $this->filterDuplicateNotifications($notifications);
+        $notifications = $this->filterByDate($notifications, $media_type_id);
 
-        $more_to_consume = !$once;
+        if (empty($notifications) && $initial_count) {
+          $this->io()
+            ->note(dt('All notifications were skipped as newer data has already been imported.'));
+        }
+        else {
+          // Take the notifications and store them in the queue for processing
+          // later.
+          $this->queueNotifications($media_type, $notifications);
+        }
+
+        $more_to_consume = $more_to_consume && !$once;
       }
 
       // Let the next listen call start from where we left off.
       $this->listener->setNotificationId($media_type_id, $last_notification);
     }
-
-    if (!empty($notifications_to_queue)) {
-      $this->logger()->info(dt('Queuing @count notifications.', ['@count' => count($notifications_to_queue)]));
-      $this->queueNotifications($media_type, $notifications_to_queue);
-    }
-    else {
-      $this->io()
-        ->note(dt('No notifications resulted in imported data.'));
-    }
-
   }
 
 }

--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -72,7 +72,7 @@ class NotificationQueuer extends DrushCommands {
    * @param array $options
    *   An array of command options.
    *
-   * @option once Only process a single notification.
+   * @option once Only process a single notification response.
    * @option reset Restarts from the earliest available notification.
    *
    * @usage media_mpx-listen mpx_video
@@ -256,7 +256,7 @@ class NotificationQueuer extends DrushCommands {
    * @param string $media_type_id
    *   The media type to listen for.
    * @param bool $once
-   *   (optional) Run once instead of until all notifications are available.
+   *   (optional) Run once instead of until all notifications are processed.
    */
   private function doListen($media_type_id, bool $once = FALSE): void {
     $more_to_consume = TRUE;

--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -274,17 +274,13 @@ class NotificationQueuer extends DrushCommands {
         ->note(dt('Waiting for a notification from mpx after notification ID @id...', ['@id' => $notification_id]));
       $notifications = $this->listener->listen($media_source, $notification_id);
 
-      // Keep track of the initial count of notifications so we can know if we
-      // filtered down to an empty array.
-      $initial_count = count($notifications);
-
       // We need a reference to the last notification so we can set the last
       // notification ID even if all notifications are filtered out.
       $last_notification = end($notifications);
 
       // Check to see if there were no notifications and we got a sync response.
       // @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications#tp-toc10
-      if ($initial_count === 1 && $last_notification->isSyncResponse()) {
+      if ($last_notification->isSyncResponse()) {
         $this->logger()->info(dt('All notifications have been processed.'));
         $more_to_consume = FALSE;
       }

--- a/src/Commands/NotificationQueuer.php
+++ b/src/Commands/NotificationQueuer.php
@@ -290,8 +290,7 @@ class NotificationQueuer extends DrushCommands {
       }
       else {
         $this->filterAndQueue($media_type, $notifications);
-
-        $more_to_consume = $more_to_consume && !$once;
+        $more_to_consume = !$once;
       }
 
       // Let the next listen call start from where we left off.

--- a/src/NotificationListener.php
+++ b/src/NotificationListener.php
@@ -150,6 +150,17 @@ class NotificationListener {
   }
 
   /**
+   * Reset the notification ID to restart from the earliest notification.
+   *
+   * @param string $media_type_id
+   *   The media type ID to reset notifications for.
+   */
+  public function resetNotificationId(string $media_type_id): void {
+    $notification_key = $this->getNotificationKey($media_type_id);
+    $this->state->delete($notification_key);
+  }
+
+  /**
    * Return the notification key in the state system.
    *
    * @param string $media_type_id


### PR DESCRIPTION
This adds a "reset" and "once" option to `mpx:listen`.

```
Listen for mpx notifications for a given media type.

Examples:
  media_mpx-listen mpx_video Listen for notifications for the mpx_video media type.

Arguments:
  media_type_id The media type ID to import for.

Options:
  --once  Only process a single notification.
  --reset Restarts from the earliest available notification.

Aliases: mpxl
```

By default, this means an `mpxl` call will pull in all available notifications at once. It seems stable for me at around 50MB of memory, and due to our notification filtering takes around 2 minutes for me to do a complete pull.

~~As well, I realized that means we can filter duplicate notifications across multiple notification results now. On my local, there are so many duplicate requests that processing all notifications leaves with 14 remaining. There's a small cost in that no notifications can be queued until the end, but a significant reduction in the number of entity saves we do later.~~

After more testing, I've reverted that. I'm seeing mpx block for _minutes_ (but not consistently) instead of returning a sync response after a reasonable time (say 60 seconds). That means that the queued notifications are stuck, and if the process is killed we lose them entirely.