### PR TITLE
Use mapped dates when calculating media availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ $factory->load('http://data.media.theplatform.com/media/data/Media/2602559', ['h
 Note that this will incur a significant performance hit on the order of 500ms
 or more, so use this option sparingly and rely on cached data where possible.
 
+## Media access and availability calculations
+
+Access to a mpx media entity is calculated using the mpx available and
+expiration dates. By default, after a site cache clear those videos will
+need to be re-fetched from mpx to have up-to-date availability dates. To
+improve performance, map the available and expiration dates to Date / Time
+fields. If available, those fields will be used to calculate access
+permissions. For details, see the
+[MediaAvailableAccess](src/Access/MediaAvailableAccess.php) class.
+
 ## Limiting results during an mpx import
 
 Sometimes sites will want to add code to alter how data is imported into

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ or more, so use this option sparingly and rely on cached data where possible.
 
 ## Media access and availability calculations
 
-Access to a mpx media entity is calculated using the mpx available and
+Access to an mpx media entity is calculated using the mpx available and
 expiration dates. By default, after a site cache clear those videos will
 need to be re-fetched from mpx to have up-to-date availability dates. To
 improve performance, map the available and expiration dates to Date / Time

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Thumbnail integration](#thumbnail-integration)
   - [Handling thumbnail errors](#handling-thumbnail-errors)
 - [Caching of mpx responses](#caching-of-mpx-responses)
+- [Media access and availability calculations](#media-access-and-availability-calculations)
 - [Limiting results during an mpx import](#limiting-results-during-an-mpx-import)
   - [1. Altering import mpx queries](#1-altering-import-mpx-queries)
   - [2. Altering ingested mpx objects](#2-altering-ingested-mpx-objects)


### PR DESCRIPTION
After a cache clear, loading an object from mpx is slower than we'd like. The most common trigger for that is checking to see if a video is available. This PR checks if the fields have been mapped, and if so uses them instead of forcing a load from mpx.

TODOs:

- [x] Update the README with this feature.

Here's a profiler comparison:

<img width="1357" alt="xhprof on 2019-01-22 13-55-14" src="https://user-images.githubusercontent.com/255023/51558408-62c67880-1e4d-11e9-9469-08014e5a049b.png">
