### PR TITLE
Fix migrate namespace for base class

### DIFF
--- a/src/Plugin/migrate/source/MediaMpxType.php
+++ b/src/Plugin/migrate/source/MediaMpxType.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\media_mpx\Plugin\migrate\source;
 
-use Drupal\paragraphs\Plugin\migrate\source\DrupalSqlBase;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
 
 /**
  * Mpx Type source plugin.


### PR DESCRIPTION
MediaMpxType does not need to inherit from Paragraph's DrupalSqlBase. It can instead inherit it from migrate_drupal. This will fix errors in sites where Paragraphs is not installed.