### PR TITLE
Add Content tag to the migration

### DIFF
--- a/migrations/d7_media_theplatform_mpx.yml
+++ b/migrations/d7_media_theplatform_mpx.yml
@@ -3,6 +3,7 @@ label: File entity to Media MPX migration
 audit: true
 migration_tags:
   - Drupal 7
+  - Content
 deriver: Drupal\media_mpx\Plugin\migrate\MpxItemDeriver
 source:
   plugin: media_mpx_entity_item


### PR DESCRIPTION
So MPX videos can be migrated along with other types of content.