### PR TITLE
Improve QueueVideoImports response objects with more meaningful data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/guzzle_cache": "^2.0",
     "symfony/cache": "^3.4",
     "highwire/drupal-psr-16": "^1.0",
-    "lullabot/mpx-php": "^0.10.0",
+    "lullabot/mpx-php": "^0.11.0",
     "lullabot/drupal-symfony-lock": "^1.0",
     "symfony/property-info": "^3.4",
     "psr/simple-cache": "^1.0"

--- a/src/Service/QueueMpxImportResult.php
+++ b/src/Service/QueueMpxImportResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_mpx\Service;
+
+use Lullabot\Mpx\DataService\Media\Media;
+
+/**
+ * Holds the result of trying to queue an mpx item for later import.
+ *
+ * @package Drupal\media_mpx\Service
+ */
+class QueueMpxImportResult {
+
+  /**
+   * Whether the queueing attempt was succesful.
+   *
+   * @var bool
+   */
+  private $success;
+
+  /**
+   * The mpx Media item.
+   *
+   * @var \Lullabot\Mpx\DataService\Media\Media
+   */
+  private $mpxMediaItem;
+
+  /**
+   * QueueMpxImportResult constructor.
+   *
+   * @param bool $success
+   *   Whether the queueing attempt was succesful or not.
+   * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
+   *   The mpx Media item.
+   */
+  public function __construct(bool $success, Media $mpx_media) {
+    $this->success = $success;
+    $this->mpxMediaItem = $mpx_media;
+  }
+
+  /**
+   * Returns whether the queuing attempt was succesful or not.
+   *
+   * @return bool
+   *   TRUE if the item was queued for later import. FALSE otherwise.
+   */
+  public function wasSuccesful(): bool {
+    return $this->success;
+  }
+
+  /**
+   * Returns the mpx Media item for which the queue attempt was done.
+   *
+   * @return \Lullabot\Mpx\DataService\Media\Media
+   *   The mpx Media item.
+   */
+  public function getMpxMediaItem(): Media {
+    return $this->mpxMediaItem;
+  }
+
+}

--- a/src/Service/QueueMpxImportResult.php
+++ b/src/Service/QueueMpxImportResult.php
@@ -30,12 +30,12 @@ class QueueMpxImportResult {
   /**
    * QueueMpxImportResult constructor.
    *
-   * @param bool $success
-   *   Whether the queueing attempt was successful or not.
    * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
    *   The mpx Media item.
+   * @param bool $success
+   *   Whether the queueing attempt was successful or not.
    */
-  public function __construct(bool $success, Media $mpx_media) {
+  public function __construct(Media $mpx_media, bool $success) {
     $this->success = $success;
     $this->mpxMediaItem = $mpx_media;
   }

--- a/src/Service/QueueMpxImportResult.php
+++ b/src/Service/QueueMpxImportResult.php
@@ -14,7 +14,7 @@ use Lullabot\Mpx\DataService\Media\Media;
 class QueueMpxImportResult {
 
   /**
-   * Whether the queueing attempt was succesful.
+   * Whether the queueing attempt was successful.
    *
    * @var bool
    */
@@ -31,7 +31,7 @@ class QueueMpxImportResult {
    * QueueMpxImportResult constructor.
    *
    * @param bool $success
-   *   Whether the queueing attempt was succesful or not.
+   *   Whether the queueing attempt was successful or not.
    * @param \Lullabot\Mpx\DataService\Media\Media $mpx_media
    *   The mpx Media item.
    */
@@ -41,12 +41,12 @@ class QueueMpxImportResult {
   }
 
   /**
-   * Returns whether the queuing attempt was succesful or not.
+   * Returns whether the queuing attempt was successful or not.
    *
    * @return bool
    *   TRUE if the item was queued for later import. FALSE otherwise.
    */
-  public function wasSuccesful(): bool {
+  public function wasSuccessful(): bool {
     return $this->success;
   }
 

--- a/src/Service/QueueVideoImports.php
+++ b/src/Service/QueueVideoImports.php
@@ -93,22 +93,16 @@ class QueueVideoImports {
     $media_type = $this->mpxMediaTypeRepository->findByTypeId($media_type_id);
 
     $results = $this->fetchMediaTypeItemIdsFromMpx($media_type, $request);
-    $queued = 0;
-    $errored = 0;
+    $queue_results = [];
+
     foreach ($results as $index => $mpx_media) {
-      if (!is_null($limit) && ($queued + $errored) >= $limit) {
+      if (!is_null($limit) && count($queue_results) >= $limit) {
         break;
       }
-
-      if ($this->queueMpxItem($mpx_media, $media_type->id()) == TRUE) {
-        $queued++;
-      }
-      else {
-        $errored++;
-      }
+      $queue_results[] = $this->queueMpxItem($mpx_media, $media_type->id());
     }
 
-    return new QueueVideoImportsResponse($queued, $errored, $results);
+    return new QueueVideoImportsResponse($queue_results, $results);
   }
 
   /**
@@ -153,22 +147,22 @@ class QueueVideoImports {
    * @param string $media_type_id
    *   The media item type id.
    *
-   * @return bool
-   *   TRUE if the item was queued successfully, FALSE otherwise.
+   * @return \Drupal\media_mpx\Service\QueueMpxImportResult
+   *   A QueueMpxImportResult object.
    */
-  protected function queueMpxItem(Media $mpx_media, string $media_type_id): bool {
+  protected function queueMpxItem(Media $mpx_media, string $media_type_id): QueueMpxImportResult {
     $import_task = new MpxImportTask($mpx_media->getId(), $media_type_id);
     if (!$this->queue->createItem($import_task)) {
       $this->logger->error(t('@type @uri could not be queued for updates.',
           ['@type' => $media_type_id, '@uri' => $mpx_media->getId()])
       );
-      return FALSE;
+      return new QueueMpxImportResult(FALSE, $mpx_media);
     }
 
     $this->logger->info(t('@type @uri has been queued to be imported.',
         ['@type' => $media_type_id, '@uri' => $mpx_media->getId()])
     );
-    return TRUE;
+    return new QueueMpxImportResult(TRUE, $mpx_media);
   }
 
 }

--- a/src/Service/QueueVideoImports.php
+++ b/src/Service/QueueVideoImports.php
@@ -156,13 +156,13 @@ class QueueVideoImports {
       $this->logger->error(t('@type @uri could not be queued for updates.',
           ['@type' => $media_type_id, '@uri' => $mpx_media->getId()])
       );
-      return new QueueMpxImportResult(FALSE, $mpx_media);
+      return new QueueMpxImportResult($mpx_media, FALSE);
     }
 
     $this->logger->info(t('@type @uri has been queued to be imported.',
         ['@type' => $media_type_id, '@uri' => $mpx_media->getId()])
     );
-    return new QueueMpxImportResult(TRUE, $mpx_media);
+    return new QueueMpxImportResult($mpx_media, TRUE);
   }
 
 }

--- a/src/Service/QueueVideoImportsResponse.php
+++ b/src/Service/QueueVideoImportsResponse.php
@@ -47,7 +47,7 @@ class QueueVideoImportsResponse {
   public function getQueuedVideos(): array {
     $queued = [];
     foreach ($this->queueResults as $result) {
-      if ($result->wasSuccesful()) {
+      if ($result->wasSuccessful()) {
         $queued[] = $result->getMpxMediaItem();
       }
     }
@@ -63,7 +63,7 @@ class QueueVideoImportsResponse {
   public function getNotQueuedVideos(): array {
     $not_queued = [];
     foreach ($this->queueResults as $result) {
-      if ($result->wasSuccesful() === FALSE) {
+      if ($result->wasSuccessful() === FALSE) {
         $not_queued[] = $result->getMpxMediaItem();
       }
     }

--- a/src/Service/QueueVideoImportsResponse.php
+++ b/src/Service/QueueVideoImportsResponse.php
@@ -16,7 +16,7 @@ class QueueVideoImportsResponse {
    *
    * @var int
    */
-  private $videosQueued;
+  private $queueResults;
 
   /**
    * The http response iterator.
@@ -26,46 +26,48 @@ class QueueVideoImportsResponse {
   private $iterator;
 
   /**
-   * The number of videos that could not be queued.
-   *
-   * @var int
-   */
-  private $errors;
-
-  /**
    * QueueVideoImportsResponse constructor.
    *
-   * @param int $videos_queued
-   *   The number of videos queued.
-   * @param int $errors
-   *   The number of videos that could not be queued.
+   * @param \Drupal\media_mpx\Service\QueueMpxImportResult[] $queueMpxImportsResults
+   *   An array of mpx import queue results.
    * @param \Lullabot\Mpx\DataService\ObjectListIterator $iterator
    *   The http response iterator.
    */
-  public function __construct(int $videos_queued, int $errors, ObjectListIterator $iterator) {
-    $this->videosQueued = $videos_queued;
+  public function __construct(array $queueMpxImportsResults, ObjectListIterator $iterator) {
+    $this->queueResults = $queueMpxImportsResults;
     $this->iterator = $iterator;
-    $this->errors = $errors;
   }
 
   /**
-   * Returns the number of videos that were queued.
+   * Returns the mpx Media Items that were successfully queued.
    *
-   * @return int
-   *   The number of videos queued.
+   * @return \Lullabot\Mpx\DataService\Media\Media[]
+   *   An array of mpx Media items.
    */
-  public function getVideosQueued(): int {
-    return $this->videosQueued;
+  public function getQueuedVideos(): array {
+    $queued = [];
+    foreach ($this->queueResults as $result) {
+      if ($result->wasSuccesful()) {
+        $queued[] = $result->getMpxMediaItem();
+      }
+    }
+    return $queued;
   }
 
   /**
-   * Returns the number of videos that could not be queued.
+   * Returns the mpx Media items that could not be queued.
    *
-   * @return int
-   *   The number of videos that could not be queued.
+   * @return \Lullabot\Mpx\DataService\Media\Media[]
+   *   An array of mpx Media items.
    */
-  public function getErrors(): int {
-    return $this->errors;
+  public function getNotQueuedVideos(): array {
+    $not_queued = [];
+    foreach ($this->queueResults as $result) {
+      if ($result->wasSuccesful() === FALSE) {
+        $not_queued[] = $result->getMpxMediaItem();
+      }
+    }
+    return $not_queued;
   }
 
   /**

--- a/tests/src/Unit/Service/QueueMpxImportResultTest.php
+++ b/tests/src/Unit/Service/QueueMpxImportResultTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\Unit\Service;
+
+use Drupal\media_mpx\Service\QueueMpxImportResult;
+use Drupal\media_mpx\Service\QueueVideoImportsResponse;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\ObjectList;
+use Lullabot\Mpx\DataService\ObjectListIterator;
+
+/**
+ * Tests response objects from the QueueVideoImport service.
+ *
+ * @group media_mpx
+ * @coversDefaultClass \Drupal\media_mpx\Service\QueueVideoImportsResponse
+ */
+class QueueVideoImportsResponseTest extends UnitTestCase {
+
+  /**
+   * @covers ::getQueuedVideos
+   * @dataProvider mpxImportResults
+   */
+  public function testGetQueuedVideos($import_results, $succesful_results, $failed_results) {
+    $iterator = $this->getDummyIterator();
+
+    $queue_service_response = new QueueVideoImportsResponse($import_results, $iterator);
+    $this->assertEquals($succesful_results, $queue_service_response->getQueuedVideos());
+  }
+
+  /**
+   * @covers ::getNotQueuedVideos
+   * @dataProvider mpxImportResults
+   */
+  public function testGetNotQueuedVideos($import_results, $succesful_results, $failed_results) {
+    $iterator = $this->getDummyIterator();
+
+    $queue_service_response = new QueueVideoImportsResponse($import_results, $iterator);
+    $this->assertEquals($failed_results, $queue_service_response->getNotQueuedVideos());
+  }
+
+  /**
+   * Returns a Dummy mpx ObjectListIterator.
+   *
+   * @return \Lullabot\Mpx\DataService\ObjectListIterator
+   *   A dummy iterator for usage in QueueVideoImportsResponse tests.
+   */
+  private function getDummyIterator(): ObjectListIterator {
+    $list = new ObjectList();
+    $promise = new Promise();
+    $promise->resolve($list);
+    $iterator = new ObjectListIterator($promise);
+    return $iterator;
+  }
+
+  /**
+   * Data provider to test queue video import service responses.
+   *
+   * @return array
+   *   An array of test cases. Each case provides:
+   *     - The array of queue import results objects (succesful and failed).
+   *     - An array of queue import result objects that could be queued.
+   *     - An array of queue import result objects that couldn't be queued.
+   */
+  public function mpxImportResults() {
+    $split_entries = [];
+    $import_results = [];
+    for ($i = 0; $i <= 10; $i++) {
+      $media_item = new Media();
+      $id = new Uri('http://data.media.theplatform.com/media/data/Media/' . rand(1, 1000));
+      $media_item->setId($id);
+
+      $succesful = !(bool) $i % 2;
+      $import_results[$i] = new QueueMpxImportResult($succesful, $media_item);
+      if ($succesful) {
+        $split_entries['succesful'][] = $media_item;
+      }
+      else {
+        $split_entries['failed'][] = $media_item;
+      }
+    }
+
+    return [
+      'Single Test Case' => [
+        $import_results,
+        $split_entries['succesful'],
+        $split_entries['failed'],
+      ],
+    ];
+  }
+
+}

--- a/tests/src/Unit/Service/QueueMpxImportResultTest.php
+++ b/tests/src/Unit/Service/QueueMpxImportResultTest.php
@@ -73,7 +73,7 @@ class QueueVideoImportsResponseTest extends UnitTestCase {
       $media_item->setId($id);
 
       $succesful = !(bool) $i % 2;
-      $import_results[$i] = new QueueMpxImportResult($succesful, $media_item);
+      $import_results[$i] = new QueueMpxImportResult($media_item, $succesful);
       if ($succesful) {
         $split_entries['succesful'][] = $media_item;
       }


### PR DESCRIPTION
## Description
- Implements feedback from https://github.com/Lullabot/media_mpx/pull/122#discussion_r284058122, although with some minor differences in regards to response handling, given the suggested snippet wasn't valid with the current `ObjectListIterator` class (e.g: calling count() on the $results array).
- Additionally to that refactor, I've leveraged it in the admin ui. Screenshot below:
- Adds unit tests for the new `QueueMpxImportResult` class.

--- 

![queue_errors](https://user-images.githubusercontent.com/890914/57771438-04324c80-7713-11e9-9264-4b599a321efe.png)

EDIT: Confirming that code climate is not complaining anymore about the refactored service 🎉  (not that it's silent, but that it actually reports a "Fixed" message for the original smell reported).
