### PR TITLE
Update asset by mpx

### DIFF
--- a/media_mpx.links.task.yml
+++ b/media_mpx.links.task.yml
@@ -8,3 +8,8 @@ media_mpx.asset_sync.single_for_video_type:
   route_name: media_mpx.asset_sync.single_for_video_type
   title: 'mpx Single Import (Type & guid)'
   parent_id: entity.media.collection
+
+media_mpx.asset_sync.single_by_mpx_id:
+  route_name: media_mpx.asset_sync.single_by_mpx_id
+  title: 'mpx Single Import (mpx ID)'
+  parent_id: entity.media.collection

--- a/media_mpx.routing.yml
+++ b/media_mpx.routing.yml
@@ -57,3 +57,13 @@ media_mpx.asset_sync.single_for_video_type:
     _permission: 'manage media_mpx asset updates'
   options:
     _admin_route: TRUE
+
+media_mpx.asset_sync.single_by_mpx_id:
+  path: '/admin/content/media/mpx/import-item-by-mpx-id'
+  defaults:
+    _title: 'Creates or Updates an mpx Item based on its mpx ID'
+    _form: \Drupal\media_mpx\Form\ImportMediaItemByMpxId
+  requirements:
+    _permission: 'manage media_mpx asset updates'
+  options:
+    _admin_route: TRUE

--- a/media_mpx.routing.yml
+++ b/media_mpx.routing.yml
@@ -62,7 +62,7 @@ media_mpx.asset_sync.single_by_mpx_id:
   path: '/admin/content/media/mpx/import-item-by-mpx-id'
   defaults:
     _title: 'Creates or Updates an mpx Item based on its mpx ID'
-    _form: \Drupal\media_mpx\Form\ImportMediaItemByMpxId
+    _form: \Drupal\media_mpx\Form\ImportVideoItemByMpxId
   requirements:
     _permission: 'manage media_mpx asset updates'
   options:

--- a/src/Form/ImportMediaItemByMpxId.php
+++ b/src/Form/ImportMediaItemByMpxId.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_mpx\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\Core\Utility\Error;
+use Drupal\media_mpx\Repository\MpxMediaType;
+use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem;
+use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form class to import a single mpx item based on its id.
+ *
+ * @package Drupal\media_mpx\Form
+ */
+class ImportMediaItemByMpxId extends FormBase {
+
+  /**
+   * The Update Video Item service.
+   *
+   * @var \Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem
+   */
+  private $updateVideoItem;
+
+  /**
+   * The system logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private $logger;
+
+  /**
+   * The media type repository.
+   *
+   * @var \Drupal\media_mpx\Repository\MpxMediaType
+   */
+  private $mpxTypeRepository;
+
+  /**
+   * UpdateMediaItemForAccount constructor.
+   */
+  public function __construct(UpdateVideoItem $updateVideoItem, MpxMediaType $mpxTypeRepository, LoggerInterface $logger) {
+    $this->updateVideoItem = $updateVideoItem;
+    $this->mpxTypeRepository = $mpxTypeRepository;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('media_mpx.service.update_video_item'),
+      $container->get('media_mpx.repository.mpx_media_types'),
+      $container->get('logger.channel.media_mpx')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    if (!$video_opts = $this->loadVideoTypeOptions()) {
+      $this->messenger()->addError($this->t('There has been an unexpected problem loading the form. Reload the page.'));
+      return [];
+    }
+
+    $form['video_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Video Type'),
+      '#description' => $this->t('Choose the video type to import the video into.'),
+      '#options' => $video_opts,
+      '#required' => TRUE,
+    ];
+    $form['mpx_id'] = [
+      '#type' => 'textfield',
+      '#title' => t('mpx item ID'),
+      '#required' => FALSE,
+    ];
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Import Item'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $mpx_id = (int) $form_state->getValue('mpx_id');
+    $video_type = $form_state->getValue('video_type');
+
+    $request = new UpdateVideoItemRequest($mpx_id, $video_type);
+    try {
+      $this->updateVideoItem->execute($request);
+      $this->messenger()->addMessage($this->t('The selected video has been imported.'));
+    }
+    catch (\Exception $e) {
+      // Up until here, all necessary checks have been made. No custom exception
+      // handling needed other than for the db possibly exploding at this point.
+      $this->messenger()->addError($this->t('There has been an unexpected problem updating the video. Check the logs for details.'));
+      $this->watchdogException($e);
+    }
+  }
+
+  /**
+   * Logs an exception.
+   *
+   * @param \Exception $exception
+   *   The exception that is going to be logged.
+   * @param string $message
+   *   The message to store in the log.
+   *
+   * @see \Drupal\Core\Utility\Error::decodeException()
+   */
+  private function watchdogException(\Exception $exception, $message = NULL) {
+    // Use a default value if $message is not set.
+    if (empty($message)) {
+      $message = '%type: @message in %function (line %line of %file).';
+    }
+
+    $variables = Error::decodeException($exception);
+    $this->logger->log(RfcLogLevel::ERROR, $message, $variables);
+  }
+
+  /**
+   * Returns the mpx Video Type options of the dropdown (prepared for form api).
+   *
+   * @return array
+   *   An array with options to show in the dropdown. The keys are the video
+   *   types, and the values are the video type label.
+   */
+  private function loadVideoTypeOptions(): array {
+    $video_opts = [];
+
+    try {
+      $video_types = $this->mpxTypeRepository->findAllTypes();
+
+      foreach ($video_types as $type) {
+        $video_opts[$type->id()] = $type->label();
+      }
+    }
+    catch (\Exception $e) {
+      $this->watchdogException($e);
+    }
+
+    return $video_opts;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'media_mpx_asset_sync_single_by_mpx_id';
+  }
+
+}

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @package Drupal\media_mpx\Form
  */
-class ImportMediaItemByMpxId extends FormBase {
+class ImportVideoItemByMpxId extends FormBase {
 
   /**
    * The Update Video Item service.

--- a/src/Service/QueueVideoImports.php
+++ b/src/Service/QueueVideoImports.php
@@ -98,7 +98,7 @@ class QueueVideoImports {
     foreach ($results as $index => $mpx_media) {
       $queue_results[] = $this->queueMpxItem($mpx_media, $media_type->id());
 
-      // Break if the limist is reached, to avoid an extra request to mpx for
+      // Break if the limit is reached, to avoid an extra request to mpx for
       // the next batch of items (which will not be used).
       if (!is_null($limit) && count($queue_results) >= $limit) {
         break;

--- a/src/Service/UpdateVideoItem/UpdateVideoItemRequest.php
+++ b/src/Service/UpdateVideoItem/UpdateVideoItemRequest.php
@@ -36,7 +36,7 @@ class UpdateVideoItemRequest {
    * @param string $mediaTypeId
    *   The media type id.
    */
-  private function __construct(int $mpxId, string $mediaTypeId) {
+  public function __construct(int $mpxId, string $mediaTypeId) {
     $this->mpxId = $mpxId;
     $this->mediaTypeId = $mediaTypeId;
   }

--- a/tests/src/Kernel/Service/UpdateVideoItemTest.php
+++ b/tests/src/Kernel/Service/UpdateVideoItemTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\Kernel\Service;
+
+use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
+use Drupal\media_mpx_test\JsonResponse;
+use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests the Account form.
+ *
+ * @group media_mpx
+ * @coversDefaultClass \Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem
+ */
+class UpdateVideoItemTest extends MediaMpxTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+    $this->installEntitySchema('media');
+
+    // Add fixtures to the guzzle handler for api requests.
+    $this->handler->append(new JsonResponse(200, [], 'signin-success.json'));
+    $this->handler->append(new JsonResponse(200, [], 'resolveDomain.json'));
+    $this->handler->append(new JsonResponse(200, [], 'media-object.json'));
+
+    // Mock http client so that it fakes correct thumbnail responses.
+    $thumbnail_handler = new MockHandler();
+    $thumbnail_handler->append(new Response(200));
+    $client = new Client(['handler' => $thumbnail_handler]);
+    $this->container->set('http_client', $client);
+  }
+
+  /**
+   * Tests video item is available from the DB after import.
+   */
+  public function testMediaItemCanBeRetrievedAfterImport() {
+    $mpx_media_type_id = $this->mediaType->get('id');
+
+    $updateService = $this->container->get('media_mpx.service.update_video_item');
+    $request = new UpdateVideoItemRequest(2602559, $mpx_media_type_id);
+
+    $updateService->execute($request);
+    $media_repository = $this->container->get('entity_type.manager')->getStorage('media');
+    $query_filters = [
+      'bundle' => $mpx_media_type_id,
+      'field_media_media_mpx_media' => 'http://data.media.theplatform.com/media/data/Media/2602559',
+    ];
+
+    $entities = $media_repository->loadByProperties($query_filters);
+    $this->assertCount(1, $entities);
+  }
+
+  /**
+   * Tests the Update Video Item service returns accurate responses.
+   */
+  public function testUpdateVideoItemResponseHasCorrectData() {
+    $updateService = $this->container->get('media_mpx.service.update_video_item');
+    $mpx_media_type_id = $this->mediaType->get('id');
+    $request = new UpdateVideoItemRequest(2602559, $mpx_media_type_id);
+
+    $response = $updateService->execute($request);
+
+    // Compare mpx item returned by the response, with the used fixtures data.
+    $fixture_response = new JsonResponse(200, [], 'media-object.json');
+    $fixture_contents = json_decode($fixture_response->getBody()->getContents());
+    $this->assertEquals($fixture_contents->guid, $response->getMpxItem()->getGuid());
+    $this->assertEquals($fixture_contents->title, $response->getMpxItem()->getTitle());
+    $this->assertEquals($fixture_contents->author, $response->getMpxItem()->getAuthor());
+    $this->assertEquals($fixture_contents->description, $response->getMpxItem()->getDescription());
+
+    // Load the item in the database and compare with the first one from the
+    // service response.
+    $media_repository = $this->container->get('entity_type.manager')->getStorage('media');
+    $query_filters = [
+      'bundle' => $mpx_media_type_id,
+      'field_media_media_mpx_media' => 'http://data.media.theplatform.com/media/data/Media/2602559',
+    ];
+    $videos = $media_repository->loadByProperties($query_filters);
+    $db_video = reset($videos);
+    $response_videos = $response->getUpdatedEntities();
+    $response_video = reset($response_videos);
+
+    $this->assertEquals($db_video->uuid(), $response_video->uuid());
+    $this->assertEquals($db_video->id(), $response_video->id());
+    $this->assertEquals($db_video->getName(), $response_video->getName());
+  }
+
+}


### PR DESCRIPTION
## Summary of Changes
- Adds a new form under `admin/content/media/mpx/update-item-by-mpx-id` that allows content managers / administrators to import (create or update) a video item by entering its `mpx ID`. Video type dropdown is required because it's needed to know mappings for the item, etc.

- Adds Kernel tests for the `UpdateVideoItem` service.