### PR TITLE
Add button to update media item from its edit form

### DIFF
--- a/media_mpx.module
+++ b/media_mpx.module
@@ -185,6 +185,10 @@ function media_mpx_migration_plugins_alter(array &$migrations) {
  * Implements hook_form_FORM_ID_alter().
  */
 function media_mpx_form_media_form_alter(&$form, $form_state, $form_id) {
-  $media_form_alter = MediaFormAlter::create(\Drupal::getContainer());
+  $mpx_type_repository = \Drupal::service('media_mpx.repository.mpx_media_types');
+  $update_service = \Drupal::service('media_mpx.service.update_video_item');
+  $logger = \Drupal::service('media_mpx.exception_logger');
+
+  $media_form_alter = new MediaFormAlter($mpx_type_repository, $update_service, $logger);
   $media_form_alter->alter($form, $form_state, $form_id);
 }

--- a/media_mpx.module
+++ b/media_mpx.module
@@ -11,6 +11,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
+use Drupal\media_mpx\FormAlter\MediaFormAlter;
 use Drupal\media_mpx\Plugin\QueueWorker\ThumbnailDownloader;
 
 /**
@@ -178,4 +179,12 @@ function media_mpx_migration_plugins_alter(array &$migrations) {
       ];
     }
   }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function media_mpx_form_media_form_alter(&$form, $form_state, $form_id) {
+  $media_form_alter = MediaFormAlter::create(\Drupal::getContainer());
+  $media_form_alter->alter($form, $form_state, $form_id);
 }

--- a/media_mpx.module
+++ b/media_mpx.module
@@ -185,10 +185,9 @@ function media_mpx_migration_plugins_alter(array &$migrations) {
  * Implements hook_form_FORM_ID_alter().
  */
 function media_mpx_form_media_form_alter(&$form, $form_state, $form_id) {
-  $mpx_type_repository = \Drupal::service('media_mpx.repository.mpx_media_types');
   $update_service = \Drupal::service('media_mpx.service.update_video_item');
   $logger = \Drupal::service('media_mpx.exception_logger');
 
-  $media_form_alter = new MediaFormAlter($mpx_type_repository, $update_service, $logger);
+  $media_form_alter = new MediaFormAlter($update_service, $logger);
   $media_form_alter->alter($form, $form_state, $form_id);
 }

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -123,7 +123,7 @@ class UpdateMediaItemForVideoType extends FormBase {
       // Up until here, all necessary checks have been made. No custom exception
       // handling needed other than for the db possibly exploding at this point.
       $this->messenger()->addError($this->t('There has been an unexpected problem updating the video. Check the logs for details.'));
-      $this->logger->watchdogException($e, sprintf('mpx video with guid %s could not be updated', $guid));
+      $this->logger->watchdogException($e, 'mpx video with guid @guid could not be updated', ['@guid' => $guid]);
     }
   }
 

--- a/src/FormAlter/MediaFormAlter.php
+++ b/src/FormAlter/MediaFormAlter.php
@@ -4,9 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\media_mpx\FormAlter;
 
-use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
-use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerTrait;
@@ -17,14 +14,13 @@ use Drupal\media_mpx\Plugin\media\Source\MpxMediaSourceInterface;
 use Drupal\media_mpx\Repository\MpxMediaType;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Alters the media form for mpx items to add "Reimport" button.
  *
  * @package Drupal\media_mpx\FormAlter
  */
-class MediaFormAlter implements ContainerInjectionInterface {
+class MediaFormAlter {
 
   use StringTranslationTrait;
   use MessengerTrait;
@@ -53,21 +49,10 @@ class MediaFormAlter implements ContainerInjectionInterface {
   /**
    * MediaFormAlter constructor.
    */
-  private function __construct(MpxMediaType $mpxMediaTypeRepository, UpdateVideoItem $updateService, MpxLogger $logger) {
+  public function __construct(MpxMediaType $mpxMediaTypeRepository, UpdateVideoItem $updateService, MpxLogger $logger) {
     $this->mpxMediaTypeRepository = $mpxMediaTypeRepository;
     $this->updateService = $updateService;
     $this->logger = $logger;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('media_mpx.repository.mpx_media_types'),
-      $container->get('media_mpx.service.update_video_item'),
-      $container->get('media_mpx.exception_logger')
-    );
   }
 
   /**

--- a/src/FormAlter/MediaFormAlter.php
+++ b/src/FormAlter/MediaFormAlter.php
@@ -11,7 +11,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\media\Entity\Media;
 use Drupal\media_mpx\MpxLogger;
 use Drupal\media_mpx\Plugin\media\Source\MpxMediaSourceInterface;
-use Drupal\media_mpx\Repository\MpxMediaType;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
 
@@ -49,8 +48,7 @@ class MediaFormAlter {
   /**
    * MediaFormAlter constructor.
    */
-  public function __construct(MpxMediaType $mpxMediaTypeRepository, UpdateVideoItem $updateService, MpxLogger $logger) {
-    $this->mpxMediaTypeRepository = $mpxMediaTypeRepository;
+  public function __construct(UpdateVideoItem $updateService, MpxLogger $logger) {
     $this->updateService = $updateService;
     $this->logger = $logger;
   }
@@ -100,17 +98,11 @@ class MediaFormAlter {
    *   The name of the field holding the mpx ID, or NULL if not configured.
    */
   private function resolveIdFieldName(Media $video):? string {
-    $id_field = NULL;
-    if ($media_type = $this->mpxMediaTypeRepository->findByTypeId($video->bundle())) {
-      $field_map = $media_type->getFieldMap();
-
-      if (!isset($field_map['Media:id'])) {
-        return NULL;
-      }
-
-      $id_field = $field_map['Media:id'];
+    if (!$field_map = $video->bundle->entity->getFieldMap()) {
+      return NULL;
     }
-    return $id_field;
+
+    return isset($field_map['Media:id']) ? $field_map['Media:id'] : NULL;
   }
 
   /**

--- a/src/FormAlter/MediaFormAlter.php
+++ b/src/FormAlter/MediaFormAlter.php
@@ -135,8 +135,8 @@ class MediaFormAlter implements ContainerInjectionInterface {
       $type_ids = [];
       foreach ($mpx_types as $key => $type) {
         $type_ids[] = $type->id();
-        return in_array($form_object->getEntity()->bundle(), $type_ids);
       }
+      return in_array($form_object->getEntity()->bundle(), $type_ids);
     }
     catch (\Exception $e) {
       return FALSE;

--- a/src/FormAlter/MediaFormAlter.php
+++ b/src/FormAlter/MediaFormAlter.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\media_mpx\FormAlter;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\media_mpx\Repository\MpxMediaType;
+use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem;
+use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Alters the media form for mpx items to add "Reimport" button.
+ *
+ * @package Drupal\media_mpx\FormAlter
+ */
+class MediaFormAlter implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The mpx media types repository.
+   *
+   * @var \Drupal\media_mpx\Repository\MpxMediaType
+   */
+  private $mpxMediaTypeRepository;
+
+  /**
+   * Update Video Item service.
+   *
+   * @var \Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem
+   */
+  private $updateService;
+
+  /**
+   * MediaFormAlter constructor.
+   */
+  private function __construct(MpxMediaType $mpxMediaTypeRepository, UpdateVideoItem $updateService) {
+    $this->mpxMediaTypeRepository = $mpxMediaTypeRepository;
+    $this->updateService = $updateService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('media_mpx.repository.mpx_media_types'),
+      $container->get('media_mpx.service.update_video_item')
+    );
+  }
+
+  /**
+   * Implements hook_form_FORM_ID_alter().
+   */
+  public function alter(&$form, FormStateInterface $form_state, $form_id): void {
+    if ($this->alterAppliesToForm($form_state) === FALSE) {
+      return;
+    }
+
+    $form['actions']['reimport'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Update with mpx data'),
+      '#submit' => [[$this, 'reimportCallback']],
+    ];
+  }
+
+  /**
+   * Callback for the 'reimport' button.
+   */
+  public function reimportCallback(array $form, FormStateInterface $formState) {
+    /* @var \Drupal\Core\Entity\ContentEntityForm $form_object */
+    $form_object = $formState->getFormObject();
+    $video = $form_object->getEntity();
+
+    $id_field = NULL;
+    if ($media_type = $this->mpxMediaTypeRepository->findByTypeId($video->bundle())) {
+      $field_map = $media_type->getFieldMap();
+      $id_field = $field_map['Media:id'] ?: NULL;
+    }
+
+    $mpx_id = $video->{$id_field}->value;
+    $this->updateVideoData((int) $mpx_id, $video->bundle());
+  }
+
+  /**
+   * Update video data and show success / error messages as relevant.
+   */
+  public function updateVideoData(int $mpxId, string $mediaTypeId) {
+    $request = new UpdateVideoItemRequest($mpxId, $mediaTypeId);
+    try {
+      $this->updateService->execute($request);
+      // @todo: success message.
+    }
+    catch (\Exception $e) {
+      \Drupal::messenger()->addError('@todo: Add error message');
+      // @todo: logging.
+    }
+  }
+
+  /**
+   * Checks if the current form needs to be altered or used in this alter class.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state object.
+   *
+   * @return bool
+   *   TRUE if this class needs to alter the form, FALSE otherwise.
+   */
+  private function alterAppliesToForm(FormStateInterface $formState): bool {
+    $form_object = $formState->getFormObject();
+
+    if (!$form_object instanceof ContentEntityForm) {
+      return FALSE;
+    }
+
+    try {
+      $mpx_types = $this->mpxMediaTypeRepository->findAllTypes();
+      $type_ids = [];
+      foreach ($mpx_types as $key => $type) {
+        $type_ids[] = $type->id();
+        return in_array($form_object->getEntity()->bundle(), $type_ids);
+      }
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/src/MpxLogger.php
+++ b/src/MpxLogger.php
@@ -84,7 +84,7 @@ class MpxLogger {
    *
    * @see \Drupal\Core\Utility\Error::decodeException()
    */
-  private function watchdogException(\Exception $exception, $message = NULL, array $variables = [], $severity = RfcLogLevel::ERROR, $link = NULL) {
+  public function watchdogException(\Exception $exception, $message = NULL, array $variables = [], $severity = RfcLogLevel::ERROR, $link = NULL) {
     // Use a default value if $message is not set.
     if (empty($message)) {
       $message = '%type: @message in %function (line %line of %file).';

--- a/src/Plugin/QueueWorker/NotificationQueueWorker.php
+++ b/src/Plugin/QueueWorker/NotificationQueueWorker.php
@@ -124,7 +124,7 @@ class NotificationQueueWorker extends QueueWorkerBase implements ContainerFactor
         $this->mpxLogger->logException($reason);
       }
       elseif ($reason instanceof \Exception) {
-        $this->watchdogException($reason);
+        $this->mpxLogger->watchdogException($reason);
       }
       else {
         $this->logger->error('An error occurred processing an mpx notification: %reason', ['%reason' => (string) $reason]);
@@ -159,39 +159,6 @@ class NotificationQueueWorker extends QueueWorkerBase implements ContainerFactor
       $factory = $this->dataObjectFactoryCreator->fromMediaSource($media_source);
       yield $factory->load($mpx_media->getId(), ['headers' => ['Cache-Control' => 'no-cache']]);
     }
-  }
-
-  /**
-   * Logs an exception.
-   *
-   * @param \Exception $exception
-   *   The exception that is going to be logged.
-   * @param string $message
-   *   The message to store in the log.
-   * @param array $variables
-   *   Array of variables to replace in the message on display or
-   *   NULL if message is already translated or not possible to
-   *   translate.
-   * @param int $severity
-   *   The severity of the message, as per RFC 3164.
-   * @param string $link
-   *   A link to associate with the message.
-   *
-   * @see \Drupal\Core\Utility\Error::decodeException()
-   */
-  private function watchdogException(\Exception $exception, $message = NULL, array $variables = [], $severity = RfcLogLevel::ERROR, $link = NULL) {
-    // Use a default value if $message is not set.
-    if (empty($message)) {
-      $message = '%type: @message in %function (line %line of %file).';
-    }
-
-    if ($link) {
-      $variables['link'] = $link;
-    }
-
-    $variables += Error::decodeException($exception);
-
-    $this->logger->log($severity, $message, $variables);
   }
 
 }


### PR DESCRIPTION
## Summary 

- Adds a "Update with mpx data" button to the mpx media forms. This will trigger the update service to get that item updated.
- Some clean up of duplicated code around exception logging.

### Remaining tasks
- [x] UI messages for success / error.
- [x] Error logging.

### Screenshots
![media_mpx_reimport](https://user-images.githubusercontent.com/890914/58094418-eb251200-7bd0-11e9-8ecd-7f3bf9840a8b.png)

**Attempt to reimport before any mapping is actually configured**
![media_mpx_configure_media_source](https://user-images.githubusercontent.com/890914/58102272-4fe86880-7be1-11e9-9f21-f16d53ef89e3.png)
