### PR TITLE
MpxImporter refactor

### DIFF
--- a/media_mpx.install
+++ b/media_mpx.install
@@ -5,9 +5,41 @@
  * Installation hooks for media_mpx.
  */
 
+use Drupal\Core\Link;
+
 /**
  * Install the new guzzle_cache dependency.
  */
 function media_mpx_update_8101() {
   \Drupal::service('module_installer')->install(['guzzle_cache']);
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function media_mpx_requirements($phase) {
+  $requirements = [];
+
+  $mpx_importer_queue = \Drupal::queue('media_mpx_importer');
+  $thumbnail_queue = \Drupal::queue('media_entity_thumbnail');
+
+  $mpx_importer_queue->numberOfItems();
+
+  if ($phase === 'runtime') {
+    $requirements['media_mpx_video_items'] = [
+      'severity' => REQUIREMENT_INFO,
+      'title' => t('Media mpx'),
+      'value' => t('mpx videos queued for import: @items', ['@items' => $mpx_importer_queue->numberOfItems()]),
+      'description' => t('Videos for specific video types can be queued from the @link or via drush.', [
+        '@link' => Link::createFromRoute('mpx Queue Contents page', 'media_mpx.asset_sync.queue_contents')->toString(),
+      ]),
+    ];
+    $requirements['media_mpx_thumbnails_items'] = [
+      'severity' => REQUIREMENT_INFO,
+      'title' => t('Media mpx - Thumbnails'),
+      'value' => t('Thumbnail items queued for processing: @items', ['@items' => $thumbnail_queue->numberOfItems()]),
+    ];
+  }
+
+  return $requirements;
 }

--- a/src/Commands/MpxImporter.php
+++ b/src/Commands/MpxImporter.php
@@ -1,10 +1,10 @@
 <?php
 
+// phpcs:disable Drupal.Commenting.FunctionComment.ParamMissingDefinition
+
 namespace Drupal\media_mpx\Commands;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
-use Drupal\media\MediaTypeInterface;
 use Drupal\media_mpx\DataObjectFactoryCreator;
 use Drupal\media_mpx\DataObjectImporter;
 use Drupal\media_mpx\Repository\MpxMediaType;
@@ -95,6 +95,7 @@ class MpxImporter extends DrushCommands {
    *
    * @param string $media_type_id
    *   The media type ID to import for.
+   *
    * @option batch_size An integer with the number of items to import per batch.
    *
    * @usage media_mpx:import {bundle}

--- a/src/MediaMpxServiceProvider.php
+++ b/src/MediaMpxServiceProvider.php
@@ -72,7 +72,7 @@ class MediaMpxServiceProvider implements ServiceProviderInterface, ServiceModifi
    */
   private function importerCommand(): Definition {
     $arguments = [
-      'entity_type.manager',
+      'media_mpx.repository.mpx_media_types',
       'media_mpx.data_object_factory_creator',
       'media_mpx.data_object_importer',
       'event_dispatcher',

--- a/src/MediaMpxServiceProvider.php
+++ b/src/MediaMpxServiceProvider.php
@@ -75,8 +75,7 @@ class MediaMpxServiceProvider implements ServiceProviderInterface, ServiceModifi
       'media_mpx.repository.mpx_media_types',
       'media_mpx.data_object_factory_creator',
       'media_mpx.data_object_importer',
-      'event_dispatcher',
-      'queue',
+      'media_mpx.service.queue_video_imports',
     ];
     $definition = new Definition(MpxImporter::class, $this->reference($arguments));
     $definition->addTag('drush.command');


### PR DESCRIPTION
## Summary of changes

- Refactor the `MpxImporter` drush command class to use some of the existing Repository and Service classes instead of keeping the update logic in that file, and removed code no longer neededas of that refactor. (Also added a batch_size option to the command).

- Status PR moved to https://github.com/Lullabot/media_mpx/pull/129. This incorporates #127 and #129, so after merging those, the diff here will contain only the refactor.

## Demo / Test Assets

Video showing command usage after the update:
https://take.ms/vNC0t
