### PR TITLE
UI: Removed traces of field_mpx_id field mapping

### DIFF
--- a/src/DataObjectImporter.php
+++ b/src/DataObjectImporter.php
@@ -94,7 +94,6 @@ class DataObjectImporter {
     // static cache.
     $reset_ids = [];
     // @todo start a transaction.
-
     // Find any existing media items, or return a new one.
     $results = $this->loadMediaEntities($media_type, $mpx_object);
 

--- a/src/Service/UpdateVideoItem/UpdateVideoItemRequest.php
+++ b/src/Service/UpdateVideoItem/UpdateVideoItemRequest.php
@@ -51,9 +51,12 @@ class UpdateVideoItemRequest {
    *   The request object, to be passed to the UpdateVideoItem service.
    */
   public static function createFromMediaEntity(Media $entity): UpdateVideoItemRequest {
-    $mpx_id = (int) $entity->get('field_mpx_id')->value;
-    $media_type_id = $entity->bundle();
-    return new self($mpx_id, $media_type_id);
+    $media_source = $entity->bundle->entity->getSource();
+    $source_field = $media_source->getSourceFieldDefinition($entity->bundle->entity);
+
+    $global_url_parts = explode('/', $entity->get($source_field->getName())->value);
+    $mpx_id = (int) end($global_url_parts);
+    return new self($mpx_id, $entity->bundle());
   }
 
   /**
@@ -68,7 +71,8 @@ class UpdateVideoItemRequest {
   public static function createFromMpxImportTask(MpxImportTask $importTask): UpdateVideoItemRequest {
     // Import tasks store the actual URI object pointing to the mpx object. Get
     // the last part only, which is the numeric id.
-    $mpx_id = (int) end(explode('/', $importTask->getMediaId()->getPath()));
+    $global_url_parts = explode('/', $importTask->getMediaId()->getPath());
+    $mpx_id = (int) end($global_url_parts);
 
     return new self($mpx_id, $importTask->getMediaTypeId());
   }

--- a/src/SimpleCacheBackendAdapter.php
+++ b/src/SimpleCacheBackendAdapter.php
@@ -190,7 +190,7 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
    *
    * Checks that the item is either permanent or did not expire.
    *
-   * @param \stdClass $cache
+   * @param object $cache
    *   An item loaded from cache_get() or cache_get_multiple().
    * @param bool $allow_invalid
    *   If TRUE, a cache item may be returned even if it is expired or has been
@@ -228,7 +228,7 @@ class SimpleCacheBackendAdapter implements CacheBackendInterface, CacheTagsInval
    * @param string[] $tags
    *   An array of cache tags.
    *
-   * @return \stdClass
+   * @return object
    *   The cache item.
    */
   private function createCacheItem($cid, $data, $expire, array $tags): \stdClass {


### PR DESCRIPTION
## Summary of changes.

- Removes 1 remaining usage of `field_mpx_id`.
- Simplifies a couple forms and allows to use the update alter one even if the **Media:Id** mapping is not configured.
- Fixes some PHPCS errors reported by Circle. They're not related to this PR, and the code that introduced them is several months old, so I'm not sure of why Circle didn't complain before!