### PR TITLE
GH-139: Added support for timestamp dates on MediaAvailableAccess::getDateTime()

### DIFF
--- a/src/Access/MediaAvailableAccess.php
+++ b/src/Access/MediaAvailableAccess.php
@@ -206,9 +206,36 @@ class MediaAvailableAccess {
    */
   private function getDateTime(MediaInterface $media, string $field_name): DateTimeFormatInterface {
     $fieldItemList = $media->get($field_name);
-    $date_time = \DateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $fieldItemList->value);
-    $date = !$fieldItemList->isEmpty() && $date_time ? new ConcreteDateTime($date_time) : new NullDateTime();
-    return $date;
+    if ($fieldItemList->isEmpty()) {
+      return new NullDateTime();
+    }
+
+    if ($date_time = \DateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $fieldItemList->value)) {
+      return new ConcreteDateTime($date_time);
+    }
+
+    // One last attempt to get a date time object if the value is a timestamp.
+    if ($this->isValidTimestamp($fieldItemList->value)) {
+      $date_time = (new \DateTime())->setTimestamp($fieldItemList->value);
+      return new ConcreteDateTime($date_time);
+    }
+
+    return new NullDateTime();
+  }
+
+  /**
+   * Checks whether a value is valid to be used as a timestamp.
+   *
+   * @param string|int $value
+   *   The value to check.
+   *
+   * @return bool
+   *   TRUE if the value is a valid timestamp, FALSE otherwise.
+   */
+  private function isValidTimestamp($value) {
+    return ((string) (int) $value === $value)
+      && ($value <= PHP_INT_MAX)
+      && ($value >= ~PHP_INT_MAX);
   }
 
 }

--- a/src/Access/MediaAvailableAccess.php
+++ b/src/Access/MediaAvailableAccess.php
@@ -215,27 +215,11 @@ class MediaAvailableAccess {
     }
 
     // One last attempt to get a date time object if the value is a timestamp.
-    if ($this->isValidTimestamp($fieldItemList->value)) {
-      $date_time = (new \DateTime())->setTimestamp($fieldItemList->value);
+    if ($date_time = \DateTime::createFromFormat('U', $fieldItemList->value)) {
       return new ConcreteDateTime($date_time);
     }
 
     return new NullDateTime();
-  }
-
-  /**
-   * Checks whether a value is valid to be used as a timestamp.
-   *
-   * @param string|int $value
-   *   The value to check.
-   *
-   * @return bool
-   *   TRUE if the value is a valid timestamp, FALSE otherwise.
-   */
-  private function isValidTimestamp($value) {
-    return ((string) (int) $value === $value)
-      && ($value <= PHP_INT_MAX)
-      && ($value >= ~PHP_INT_MAX);
   }
 
 }

--- a/tests/src/FunctionalJavascript/CustomFieldMapTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldMapTest.php
@@ -16,8 +16,14 @@ use Drupal\media_mpx_test\JsonResponse;
  */
 class CustomFieldMapTest extends WebDriverTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected $minkDefaultDriverClass = DrupalSelenium2Driver::class;
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'media_mpx',
     'media_mpx_test',

--- a/tests/src/FunctionalJavascript/FieldMapTest.php
+++ b/tests/src/FunctionalJavascript/FieldMapTest.php
@@ -16,8 +16,14 @@ use Drupal\media_mpx_test\JsonResponse;
  */
 class FieldMapTest extends WebDriverTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected $minkDefaultDriverClass = DrupalSelenium2Driver::class;
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'media_mpx',
     'media_mpx_test',

--- a/tests/src/FunctionalJavascript/PlayerFormatterTest.php
+++ b/tests/src/FunctionalJavascript/PlayerFormatterTest.php
@@ -16,8 +16,14 @@ use Drupal\media_mpx_test\JsonResponse;
  */
 class PlayerFormatterTest extends WebDriverTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected $minkDefaultDriverClass = DrupalSelenium2Driver::class;
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'media_mpx',
     'media_mpx_test',

--- a/tests/src/Kernel/Access/MediaAvailableAccessTest.php
+++ b/tests/src/Kernel/Access/MediaAvailableAccessTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Drupal\Tests\media_mpx\Kernel\Access;
+
+use Drupal\Core\Access\AccessResultForbidden;
+use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\media\Entity\Media;
+use Drupal\Tests\media_mpx\Kernel\MediaMpxTestBase;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the MediaAvailableAccess service.
+ *
+ * @group media_mpx
+ * @coversDefaultClass \Drupal\media_mpx\Access\MediaAvailableAccess
+ */
+class MediaAvailableAccessTest extends MediaMpxTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'field',
+    'file',
+    'datetime',
+    'user',
+    'image',
+    'guzzle_cache',
+    'media',
+    'media_mpx',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+    $this->installEntitySchema('media');
+
+    $this->createExpirationAndAvailableFields();
+  }
+
+  /**
+   * Tests Media Available Access can handle timestamp access fields.
+   *
+   * @covers ::getDateTime
+   */
+  public function testAccessChecksForMediaItemWithTimestampFields() {
+    $anonymous = User::getAnonymousUser();
+    $media = Media::create([
+      'bundle' => $this->mediaType->get('id'),
+      'title' => 'test available access',
+      'field_media_media_mpx_media' => 'http://example.com/1234',
+    ]);
+
+    $field_map = [];
+    $field_map['Media:availableDate'] = 'field_available_date_timestamp';
+    $field_map['Media:expirationDate'] = 'field_expiration_date_timestamp';
+    $this->mediaType->setFieldMap($field_map);
+    $this->mediaType->save();
+
+    /** @var \Drupal\media_mpx\Access\MediaAvailableAccess $available_access_service */
+    $available_access_service = $this->container->get('media_mpx.media_available_access');
+
+    $combinations = $this->timestampValuesWithAccessResultsProvider();
+    foreach ($combinations as $combination) {
+      list($available, $expiration, $expectedClass) = $combination;
+      $media->set('field_available_date_timestamp', $available);
+      $media->set('field_expiration_date_timestamp', $expiration);
+      $access = $available_access_service->view($media, $anonymous);
+      $this->assertInstanceOf($expectedClass, $access);
+    }
+  }
+
+  /**
+   * Tests Media Available Access can handle datetime access fields.
+   *
+   * @covers ::getDateTime
+   */
+  public function testAccessChecksForMediaItemWithDateTimeFields() {
+    $anonymous = User::getAnonymousUser();
+    $media = Media::create([
+      'bundle' => $this->mediaType->get('id'),
+      'title' => 'test available access',
+      'field_media_media_mpx_media' => 'http://example.com/1234',
+    ]);
+
+    $field_map = [];
+    $field_map['Media:availableDate'] = 'field_available_date_datetime';
+    $field_map['Media:expirationDate'] = 'field_expiration_date_datetime';
+    $this->mediaType->setFieldMap($field_map);
+    $this->mediaType->save();
+
+    /** @var \Drupal\media_mpx\Access\MediaAvailableAccess $available_access_service */
+    $available_access_service = $this->container->get('media_mpx.media_available_access');
+
+    $combinations = $this->dateTimeValuesWithAccessResultsProvider();
+    foreach ($combinations as $combination) {
+      list($available, $expiration, $expectedClass) = $combination;
+      $media->set('field_available_date_datetime', $available->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT));
+      $media->set('field_expiration_date_datetime', $expiration->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT));
+      $access = $available_access_service->view($media, $anonymous);
+      $this->assertInstanceOf($expectedClass, $access);
+    }
+  }
+
+  /**
+   * Data provider of available and expiration dates as timestamps.
+   *
+   * Not used via the @dataProvider annotation on purpose, as that'll make each
+   * iteration run the setUp logic, which is not desired for these tests.
+   *
+   * @return array
+   *   The array of values to test with, alongside the expected access result
+   *   for each case.
+   */
+  public function timestampValuesWithAccessResultsProvider() {
+    return [
+      // Available | Expiration | expected AccessResult object.
+      [time() - 86400, time() + 3600, AccessResultNeutral::class],
+      [time() + 3600, time() + 7200, AccessResultForbidden::class],
+      [time() - 3600, time() - 1800, AccessResultForbidden::class],
+      [time() + 3600, time() - 1800, AccessResultForbidden::class],
+    ];
+  }
+
+  /**
+   * Data provider of available and expiration dates as datetime objects.
+   *
+   * Not used via the @dataProvider annotation on purpose, as that'll make each
+   * iteration run the setUp logic, which is not desired for these tests.
+   *
+   * @return array
+   *   The array of values to test with, alongside the expected access result
+   *   for each case.
+   */
+  public function dateTimeValuesWithAccessResultsProvider() {
+    return [
+      // Available | Expiration | expected AccessResult object.
+      [
+        \DateTime::createFromFormat('U', time() - 86400),
+        \DateTime::createFromFormat('U', time() + 86400),
+        AccessResultNeutral::class,
+      ],
+      [
+        \DateTime::createFromFormat('U', time() + 86400),
+        \DateTime::createFromFormat('U', time() + 100000),
+        AccessResultForbidden::class,
+      ],
+      [
+        \DateTime::createFromFormat('U', time() - 3600),
+        \DateTime::createFromFormat('U', time() - 28800),
+        AccessResultForbidden::class,
+      ],
+      [
+        \DateTime::createFromFormat('U', time() + 3600),
+        \DateTime::createFromFormat('U', time() - 1800),
+        AccessResultForbidden::class,
+      ],
+    ];
+  }
+
+  /**
+   * Creates necessary datetime and integer fields for Access tests.
+   */
+  protected function createExpirationAndAvailableFields(): void {
+    $mpx_media_type_id = $this->mediaType->get('id');
+    $field_avail_timestamp_storage = FieldStorageConfig::create([
+      'field_name' => 'field_available_date_timestamp',
+      'entity_type' => 'media',
+      'type' => 'integer',
+      'cardinality' => 1,
+    ]);
+    $field_avail_timestamp_storage->save();
+
+    $field_avail_timestamp = FieldConfig::create([
+      'field_storage' => $field_avail_timestamp_storage,
+      'field_name' => 'field_available_date_timestamp',
+      'label' => 'Available Date - Timestamp',
+      'description' => 'Available Date stored as a timestamp',
+      'entity_type' => 'media',
+      'bundle' => $mpx_media_type_id,
+      'required' => TRUE,
+    ]);
+    $field_avail_timestamp->save();
+
+    $field_exp_timestamp_storage = FieldStorageConfig::create([
+      'field_name' => 'field_expiration_date_timestamp',
+      'entity_type' => 'media',
+      'type' => 'integer',
+      'cardinality' => 1,
+    ]);
+    $field_exp_timestamp_storage->save();
+
+    $field_exp_timestamp = FieldConfig::create([
+      'field_storage' => $field_exp_timestamp_storage,
+      'field_name' => 'field_expiration_date_timestamp',
+      'label' => 'Expiration Date - Timestamp',
+      'description' => 'Expiration Date stored as a timestamp',
+      'entity_type' => 'media',
+      'bundle' => $mpx_media_type_id,
+      'required' => TRUE,
+    ]);
+    $field_exp_timestamp->save();
+
+    $field_avail_datetime_storage = FieldStorageConfig::create([
+      'field_name' => 'field_available_date_datetime',
+      'entity_type' => 'media',
+      'type' => 'datetime',
+      'settings' => ['datetime_type' => DateTimeItem::DATETIME_TYPE_DATE],
+      'cardinality' => 1,
+    ]);
+    $field_avail_datetime_storage->save();
+
+    $field_avail_datetime = FieldConfig::create([
+      'field_storage' => $field_avail_datetime_storage,
+      'field_name' => 'field_available_date_datetime',
+      'label' => 'Available Date - Datetime',
+      'description' => 'Available Date stored as datetime data.',
+      'entity_type' => 'media',
+      'bundle' => $mpx_media_type_id,
+      'required' => TRUE,
+    ]);
+    $field_avail_datetime->save();
+
+    $field_exp_datetime_storage = FieldStorageConfig::create([
+      'field_name' => 'field_expiration_date_datetime',
+      'entity_type' => 'media',
+      'type' => 'datetime',
+      'settings' => ['datetime_type' => DateTimeItem::DATETIME_TYPE_DATE],
+      'cardinality' => 1,
+    ]);
+    $field_exp_datetime_storage->save();
+
+    $field_exp_datetime = FieldConfig::create([
+      'field_storage' => $field_exp_datetime_storage,
+      'field_name' => 'field_expiration_date_datetime',
+      'label' => 'Expiration Date - Datetime',
+      'description' => 'Expiration Date stored as datetime data.',
+      'entity_type' => 'media',
+      'bundle' => $mpx_media_type_id,
+      'required' => TRUE,
+    ]);
+    $field_exp_datetime->save();
+  }
+
+}


### PR DESCRIPTION
- Fixes https://github.com/Lullabot/media_mpx/issues/139
- Fixes some PHPCS errors that appeared, though they were unrelated to this PR.
- Adds kernel test to cover availability window access checks on `MediaAvailableAccess` service.

- Opened https://github.com/Lullabot/media_mpx/issues/141.