### PR TITLE
Issue #142 Import single messaging for filtered videos

### DIFF
--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -79,8 +79,8 @@ class ImportVideoItemByMpxId extends FormBase {
     ];
     $form['mpx_id'] = [
       '#type' => 'textfield',
-      '#title' => t('ID'),
-      '#placeholder' => 'Type the ID of the mpx video you want to import.',
+      '#title' => $this->t('ID'),
+      '#placeholder' => $this->t('Type the ID of the mpx video you want to import.'),
       '#required' => FALSE,
     ];
     $form['actions']['#type'] = 'actions';

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -7,6 +7,7 @@ namespace Drupal\media_mpx\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media_mpx\MpxLogger;
+use Drupal\media_mpx\Plugin\media\Source\Media;
 use Drupal\media_mpx\Repository\MpxMediaType;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItem;
 use Drupal\media_mpx\Service\UpdateVideoItem\UpdateVideoItemRequest;
@@ -104,9 +105,9 @@ class ImportVideoItemByMpxId extends FormBase {
       $response = $this->updateVideoItem->execute($request);
       if (empty($response->getUpdatedEntities())) {
         $mpx_media = $response->getMpxItem();
-        $this->messenger()->addWarning($this->t("The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
+        $this->messenger()->addWarning($this->t("The selected video: @video_title (@id) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
           '@video_title' => $mpx_media->getTitle(),
-          '@guid' => $mpx_media->getGuid(),
+          '@id' => Media::getMpxObjectIdFromUri((string) $mpx_media->getId()),
         ]));
       }
       else {
@@ -116,7 +117,7 @@ class ImportVideoItemByMpxId extends FormBase {
     catch (\Exception $e) {
       // Up until here, all necessary checks have been made. No custom exception
       // handling needed other than for the db possibly exploding at this point.
-      $this->messenger()->addError($this->t('There has been an unexpected problem updating the video. Check the logs for details.'));
+      $this->messenger()->addError($this->t('There has been an unexpected problem importing the video. Check the logs for details.'));
       $this->logger->watchdogException($e);
     }
   }

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -98,8 +98,16 @@ class ImportVideoItemByMpxId extends FormBase {
 
     $request = new UpdateVideoItemRequest($mpx_id, $video_type);
     try {
-      $this->updateVideoItem->execute($request);
-      $this->messenger()->addMessage($this->t('The selected video has been imported.'));
+      $response = $this->updateVideoItem->execute($request);
+      if (empty($response->getUpdatedEntities())) {
+        $this->messenger()->addWarning($this->t('The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it\'s available to be imported and try again.', [
+          '@video_title' => $mpx_media->getTitle(),
+          '@guid' => $mpx_media->getGuid(),
+        ]));
+      }
+      else {
+        $this->messenger()->addMessage($this->t('The selected video has been imported.'));
+      }
     }
     catch (\Exception $e) {
       // Up until here, all necessary checks have been made. No custom exception

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -71,19 +71,22 @@ class ImportVideoItemByMpxId extends FormBase {
 
     $form['video_type'] = [
       '#type' => 'select',
-      '#title' => $this->t('Video Type'),
+      '#title' => $this->t('Video type'),
       '#description' => $this->t('Choose the video type to import the video into.'),
       '#options' => $video_opts,
       '#required' => TRUE,
     ];
     $form['mpx_id'] = [
       '#type' => 'textfield',
-      '#title' => t('mpx item ID'),
+      '#title' => t('ID'),
+      '#placeholder' => 'Type the ID of the mpx video you want to import.',
       '#required' => FALSE,
     ];
-    $form['submit'] = [
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Import Item'),
+      '#value' => $this->t('Import video'),
+      '#button_type' => 'primary',
     ];
 
     return $form;

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -103,7 +103,8 @@ class ImportVideoItemByMpxId extends FormBase {
     try {
       $response = $this->updateVideoItem->execute($request);
       if (empty($response->getUpdatedEntities())) {
-        $this->messenger()->addWarning($this->t('The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it\'s available to be imported and try again.', [
+        $mpx_media = $response->getMpxItem();
+        $this->messenger()->addWarning($this->t("The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
           '@video_title' => $mpx_media->getTitle(),
           '@guid' => $mpx_media->getGuid(),
         ]));

--- a/src/Form/ImportVideoItemByMpxId.php
+++ b/src/Form/ImportVideoItemByMpxId.php
@@ -105,7 +105,7 @@ class ImportVideoItemByMpxId extends FormBase {
       $response = $this->updateVideoItem->execute($request);
       if (empty($response->getUpdatedEntities())) {
         $mpx_media = $response->getMpxItem();
-        $this->messenger()->addWarning($this->t("The selected video: @video_title (@id) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
+        $this->messenger()->addWarning($this->t("The selected video: @video_title (@id) did not import. There may be one or more custom business rules in place which filtered it out. Consult the site administrator, adjust the video metadata in mpx to ensure it's available to be imported, and try again.", [
           '@video_title' => $mpx_media->getTitle(),
           '@id' => Media::getMpxObjectIdFromUri((string) $mpx_media->getId()),
         ]));

--- a/src/Form/QueueContentsForm.php
+++ b/src/Form/QueueContentsForm.php
@@ -50,7 +50,7 @@ class QueueContentsForm extends FormBase {
 
     $form['mpx_video_types'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Mpx video types'),
+      '#title' => $this->t('mpx Video types'),
       '#options' => $options,
       '#required' => TRUE,
     ];

--- a/src/Form/QueueContentsForm.php
+++ b/src/Form/QueueContentsForm.php
@@ -50,13 +50,15 @@ class QueueContentsForm extends FormBase {
 
     $form['mpx_video_types'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('mpx Video Types'),
+      '#title' => $this->t('Mpx video types'),
       '#options' => $options,
       '#required' => TRUE,
     ];
-    $form['queue'] = [
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['queue'] = [
       '#type' => 'submit',
       '#value' => $this->t('Import videos'),
+      '#button_type' => 'primary',
     ];
 
     return $form;

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -172,7 +172,7 @@ class UpdateMediaItemForVideoType extends FormBase {
     $response = $this->updateVideoItemService->execute($request);
     if (empty($response->getUpdatedEntities())) {
       $mpx_media = $response->getMpxItem();
-      $this->messenger()->addWarning($this->t("The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
+      $this->messenger()->addWarning($this->t("The selected video: @video_title (@guid) did not import. There may be one or more custom business rules in place which filtered it out. Consult the site administrator, adjust the video metadata in mpx to ensure it's available to be imported, and try again.", [
         '@video_title' => $mpx_media->getTitle(),
         '@guid' => $mpx_media->getGuid(),
       ]));

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -169,8 +169,17 @@ class UpdateMediaItemForVideoType extends FormBase {
    *   Success text to be used on the notification.
    */
   private function submitFormExecuteRequest(UpdateVideoItemRequest $request, string $success_text) {
-    $this->updateVideoItemService->execute($request);
-    $this->messenger()->addMessage($success_text);
+    $response = $this->updateVideoItemService->execute($request);
+    if (empty($response->getUpdatedEntities())) {
+      $mpx_media = $response->getMpxItem();
+      $this->messenger()->addWarning($this->t('The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it\'s available to be imported and try again.', [
+        '@video_title' => $mpx_media->getTitle(),
+        '@guid' => $mpx_media->getGuid(),
+      ]));
+    }
+    else {
+      $this->messenger()->addMessage($success_text);
+    }
   }
 
   /**

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -103,7 +103,7 @@ class UpdateMediaItemForVideoType extends FormBase {
     ];
     $form['guid'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Guid'),
+      '#title' => $this->t('GUID'),
       '#placeholder' => 'Type the GUID of the mpx video you want to import.',
       '#required' => TRUE,
     ];

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -96,21 +96,22 @@ class UpdateMediaItemForVideoType extends FormBase {
 
     $form['video_type'] = [
       '#type' => 'select',
-      '#title' => $this->t('Video Type'),
+      '#title' => $this->t('Video type'),
       '#description' => $this->t('Choose the video type to import the video into.'),
       '#options' => $video_opts,
       '#required' => TRUE,
     ];
     $form['guid'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('guid'),
-      '#placeholder' => 'Type the GUID of the mpx item you want to import.',
+      '#title' => $this->t('Guid'),
+      '#placeholder' => 'Type the GUID of the mpx video you want to import.',
       '#required' => TRUE,
     ];
-
-    $form['submit'] = [
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Update item'),
+      '#value' => $this->t('Import video'),
+      '#button_type' => 'primary',
     ];
 
     return $form;
@@ -153,9 +154,8 @@ class UpdateMediaItemForVideoType extends FormBase {
       $this->submitFormExecuteRequest($request, $success_text);
     }
     catch (\Exception $e) {
-      // Up until here, all necessary checks have been made. No custom
-      // exception handling needed other than for the db possibly
-      // exploding at this point.
+      // Up until here, all necessary checks have been made. No custom exception
+      // handling needed other than for the db possibly exploding at this point.
       $this->submitFormReportError($guid, $e, $error_text);
     }
   }

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -132,8 +132,8 @@ class UpdateMediaItemForVideoType extends FormBase {
       $this->submitFormProcessRequest($request, $guid, $success_text, $error_text);
       return;
     }
-    $guid_not_found_exception = new \Exception("Given guid doesn't exist, please check and try again.");
-    $error_text = (string) $this->t("Given guid doesn't exist, please check and try again.");
+    $guid_not_found_exception = new \RuntimeException(sprintf("Given guid (%s) doesn't exist, please check and try again.", $guid));
+    $error_text = (string) $this->t("Given guid (@guid) doesn't exist, please check and try again.", ['@guid' => $guid]);
     $this->submitFormReportError($guid, $guid_not_found_exception, $error_text);
   }
 

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -172,7 +172,7 @@ class UpdateMediaItemForVideoType extends FormBase {
     $response = $this->updateVideoItemService->execute($request);
     if (empty($response->getUpdatedEntities())) {
       $mpx_media = $response->getMpxItem();
-      $this->messenger()->addWarning($this->t('The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it\'s available to be imported and try again.', [
+      $this->messenger()->addWarning($this->t("The selected video: @video_title (@guid) did not import. The video was filtered out by one or more custom import filters. Adjust the video metadata in mpx to ensure it's available to be imported and try again.", [
         '@video_title' => $mpx_media->getTitle(),
         '@guid' => $mpx_media->getGuid(),
       ]));

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -132,8 +132,8 @@ class UpdateMediaItemForVideoType extends FormBase {
       $this->submitFormProcessRequest($request, $guid, $success_text, $error_text);
       return;
     }
-    $guid_not_found_exception = new \Exception("Given GUID doesn't exist, please check and try again.");
-    $error_text = (string) $this->t("Given GUID doesn't exist, please check and try again.");
+    $guid_not_found_exception = new \Exception("Given guid doesn't exist, please check and try again.");
+    $error_text = (string) $this->t("Given guid doesn't exist, please check and try again.");
     $this->submitFormReportError($guid, $guid_not_found_exception, $error_text);
   }
 


### PR DESCRIPTION
Resolves #142 using a generic warning message to indicate to the user that something didn't import. Better would be if we could be more specific. That would take some additional work, so I felt it was worth the small increment first.

Also tidies up the copy on all the import forms a bit to be more consistent.