### PR TITLE
Remove foreach and clean up form page titles

### DIFF
--- a/media_mpx.routing.yml
+++ b/media_mpx.routing.yml
@@ -51,7 +51,7 @@ media_mpx.asset_sync.queue_videos:
 media_mpx.asset_sync.single_for_video_type:
   path: '/admin/content/media/mpx/update-item-for-video-type'
   defaults:
-    _title: 'Update an mpx Item for a given Video type'
+    _title: 'Import mpx video by GUID'
     _form: \Drupal\media_mpx\Form\UpdateMediaItemForVideoType
   requirements:
     _permission: 'manage media_mpx asset updates'
@@ -61,7 +61,7 @@ media_mpx.asset_sync.single_for_video_type:
 media_mpx.asset_sync.single_by_mpx_id:
   path: '/admin/content/media/mpx/import-item-by-mpx-id'
   defaults:
-    _title: 'Creates or Updates an mpx Item based on its mpx ID'
+    _title: 'Import mpx video by Full ID'
     _form: \Drupal\media_mpx\Form\ImportVideoItemByMpxId
   requirements:
     _permission: 'manage media_mpx asset updates'

--- a/src/Form/UpdateMediaItemForVideoType.php
+++ b/src/Form/UpdateMediaItemForVideoType.php
@@ -245,11 +245,7 @@ class UpdateMediaItemForVideoType extends FormBase {
     $factory = $this->dataObjectFactoryCreator->fromMediaSource($media_source);
 
     $results = $factory->select($query);
-    $queues = [];
-    foreach ($results as $index => $mpx_media) {
-      $queues[] = $mpx_media;
-    }
-    return reset($queues) ?: NULL;
+    return ($results->valid() ? $results->current() : NULL);
   }
 
   /**


### PR DESCRIPTION
Instead of foreach, we can just pop the first video off of the iterator. This also cleans up the form page titles.

<img width="789" alt="Screen Shot 2019-07-18 at 1 58 36 PM" src="https://user-images.githubusercontent.com/255023/61480546-31de8080-a964-11e9-862c-354344b3ec40.png">
