### PR TITLE
Fix using the wrong string for update permissions

### DIFF
--- a/src/Access/MediaAvailableAccess.php
+++ b/src/Access/MediaAvailableAccess.php
@@ -65,8 +65,8 @@ class MediaAvailableAccess {
       return AccessResult::neutral();
     }
 
-    // If you can edit an entity, don't apply availability rules.
-    if ($media->access('edit', $account)) {
+    // If you can update an entity, don't apply availability rules.
+    if ($media->access('update', $account)) {
       return AccessResult::neutral();
     }
 

--- a/tests/src/Kernel/Access/MediaAvailableAccessTest.php
+++ b/tests/src/Kernel/Access/MediaAvailableAccessTest.php
@@ -199,7 +199,7 @@ class MediaAvailableAccessTest extends MediaMpxTestBase {
   /**
    * Creates necessary datetime and integer fields for Access tests.
    */
-  protected function createExpirationAndAvailableFields(): void {
+  protected function createExpirationAndAvailableFields() {
     $mpx_media_type_id = $this->mediaType->get('id');
     $field_avail_timestamp_storage = FieldStorageConfig::create([
       'field_name' => 'field_available_date_timestamp',
@@ -295,6 +295,7 @@ class MediaAvailableAccessTest extends MediaMpxTestBase {
    * Create a media entity.
    *
    * @return \Drupal\media\Entity\Media
+   *   Returns an unsaved media entity.
    */
   private function createMedia() {
     $media = Media::create([


### PR DESCRIPTION
I really wish core used a constant or class so this could be a compile time and not runtime error that silently fails!